### PR TITLE
bakery: implement key marshaling

### DIFF
--- a/bakery/example/idservice/targetservice_test.go
+++ b/bakery/example/idservice/targetservice_test.go
@@ -35,7 +35,7 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("adding public key for location %s: %x", authEndpoint, authPK[:])
+	log.Printf("adding public key for location %s: %v", authEndpoint, authPK)
 	pkLocator.AddPublicKeyForLocation(authEndpoint, true, authPK)
 	mux := http.NewServeMux()
 	srv := &targetServiceHandler{

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -37,7 +37,7 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("adding public key for location %s: %x", authEndpoint, authPK[:])
+	log.Printf("adding public key for location %s: %v", authEndpoint, authPK)
 	pkLocator.AddPublicKeyForLocation(authEndpoint, true, authPK)
 	mux := http.NewServeMux()
 	srv := &targetServiceHandler{

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -1,0 +1,64 @@
+package bakery_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+)
+
+type KeysSuite struct{}
+
+var _ = gc.Suite(&KeysSuite{})
+
+var testKey = bakery.Key{
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+}
+
+func (*KeysSuite) TestMarshalBinary(c *gc.C) {
+	data, err := testKey.MarshalBinary()
+	c.Assert(err, gc.IsNil)
+	c.Assert(data, jc.DeepEquals, []byte(testKey[:]))
+
+	var key1 bakery.Key
+	err = key1.UnmarshalBinary(data)
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, gc.DeepEquals, testKey)
+}
+
+func (*KeysSuite) TestMarshalText(c *gc.C) {
+	data, err := testKey.MarshalText()
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Equals, base64.StdEncoding.EncodeToString([]byte(testKey[:])))
+
+	var key1 bakery.Key
+	err = key1.UnmarshalText(data)
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, gc.Equals, testKey)
+}
+
+func (*KeysSuite) TestKeyPairMarshalJSON(c *gc.C) {
+	kp := bakery.KeyPair{
+		Public:  bakery.PublicKey{testKey},
+		Private: bakery.PrivateKey{testKey},
+	}
+	kp.Private.Key[0] = 99
+	data, err := json.Marshal(kp)
+	c.Assert(err, gc.IsNil)
+	var x interface{}
+	err = json.Unmarshal(data, &x)
+	c.Assert(err, gc.IsNil)
+
+	// Check that the fields have marshaled as strings.
+	c.Assert(x.(map[string]interface{})["private"], gc.FitsTypeOf, "")
+	c.Assert(x.(map[string]interface{})["public"], gc.FitsTypeOf, "")
+
+	var kp1 bakery.KeyPair
+	err = json.Unmarshal(data, &kp1)
+	c.Assert(err, gc.IsNil)
+	c.Assert(kp1, jc.DeepEquals, kp)
+}

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -171,12 +171,11 @@ func (d *dischargeHandler) serveCreate(h http.Header, req *http.Request) (interf
 }
 
 type publicKeyResponse struct {
-	PublicKey []byte
+	PublicKey *bakery.PublicKey
 }
 
 func (d *dischargeHandler) servePublicKey(h http.Header, r *http.Request) (interface{}, error) {
-	key := d.svc.PublicKey()
-	return publicKeyResponse{key[:]}, nil
+	return publicKeyResponse{d.svc.PublicKey()}, nil
 }
 
 func randomBytes(n int) ([]byte, error) {


### PR DESCRIPTION
We change the types of keys so that they can both use the same
marshaling and unmarshaling code.

This is an API-breaking change.
