### PR TITLE
bakery: more intelligent prefix handling for PublicKeyRing

### DIFF
--- a/httpbakery/service_test.go
+++ b/httpbakery/service_test.go
@@ -8,10 +8,10 @@ import (
 	"net/url"
 
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"gopkg.in/macaroon-bakery.v0/bakery"
 	"gopkg.in/macaroon-bakery.v0/httpbakery"
-	"gopkg.in/macaroon.v1"
 )
 
 type ServiceSuite struct{}


### PR DESCRIPTION
The previous string-prefix-based handling was seriously flawed.
