### PR TITLE
bakery/mgostorage: do not return private type

### DIFF
--- a/bakery/mgostorage/storage.go
+++ b/bakery/mgostorage/storage.go
@@ -13,7 +13,7 @@ import (
 
 // New returns an implementation of Storage
 // that stores all items in MongoDB.
-func New(c *mgo.Collection) (*mgoStorage, error) {
+func New(c *mgo.Collection) (bakery.Storage, error) {
 	m := mgoStorage{
 		col: c,
 	}


### PR DESCRIPTION
It's not good practice to return private types.
