### PR TITLE
httpbakery: expose slightly more errors machinery

### DIFF
--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -27,9 +27,9 @@ const (
 )
 
 var (
-	handleJSON   = jsonhttp.HandleJSON(errorToResponse)
-	handleErrors = jsonhttp.HandleErrors(errorToResponse)
-	writeError   = jsonhttp.WriteError(errorToResponse)
+	handleJSON   = jsonhttp.HandleJSON(ErrorToResponse)
+	handleErrors = jsonhttp.HandleErrors(ErrorToResponse)
+	writeError   = jsonhttp.WriteError(ErrorToResponse)
 )
 
 // Error holds the type of a response from an httpbakery HTTP request,
@@ -78,7 +78,11 @@ func (e *Error) ErrorInfo() *ErrorInfo {
 	return e.Info
 }
 
-func errorToResponse(err error) (int, interface{}) {
+// ErrorToResponse returns the HTTP status and an error body to be
+// marshaled as JSON for the given error. This allows a third party
+// package to integrate bakery errors into their error responses when
+// they encounter an error with a *bakery.Error cause.
+func ErrorToResponse(err error) (int, interface{}) {
 	errorBody := errorResponseBody(err)
 	status := http.StatusInternalServerError
 	switch errorBody.Code {

--- a/httpbakery/handler.go
+++ b/httpbakery/handler.go
@@ -14,10 +14,10 @@ type dischargeRequestedResponse struct {
 	Macaroon  *macaroon.Macaroon
 }
 
-// WriteDischargeRequiredError writes a response to w that reports the
-// given error and sends the given macaroon to the client, indicating
-// that it should be discharged to allow the original request to be
-// accepted.
+// WriteDischargeRequiredError creates an error using
+// NewDischargeRequiredError and writes it to the given response writer,
+// indicating that the client should discharge the macaroon to allow the
+// original request to be accepted.
 func WriteDischargeRequiredError(w http.ResponseWriter, m *macaroon.Macaroon, originalErr error) {
 	log.Printf("write discharge required error")
 	if originalErr == nil {
@@ -30,6 +30,19 @@ func WriteDischargeRequiredError(w http.ResponseWriter, m *macaroon.Macaroon, or
 			Macaroon: m,
 		},
 	})
+}
+
+// NewDischargeRequiredError returns an error of type *Error
+// that reports the given original error and includes the
+// given macaroon.
+func NewDischargeRequiredError(m *macaroon.Macaroon, originalErr error) error {
+	return &Error{
+		Message: originalErr.Error(),
+		Code:    ErrDischargeRequired,
+		Info: &ErrorInfo{
+			Macaroon: m,
+		},
+	}
 }
 
 // It remains to be seen whether the following code is useful


### PR DESCRIPTION
We want to be able to integrate httpbakery into an existing JSON
framework.
