### PR TITLE
bakery/checkers: add Declared and InferDeclared

### DIFF
--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -11,6 +11,12 @@ import (
 	"gopkg.in/macaroon-bakery.v0/bakery"
 )
 
+// Constants for all the standard caveat conditions.
+const (
+	CondDeclared   = "declared"
+	CondTimeBefore = "time-before"
+)
+
 // Checker is implemented by types that can check caveats.
 type Checker interface {
 	// Condition returns the identifier of the condition

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon.v1"
 
 	"gopkg.in/macaroon-bakery.v0/bakery"
 	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
@@ -176,6 +178,39 @@ var checkerTests = []struct {
 		caveat:      checkers.TimeBeforeCaveat(now).Condition + " ",
 		expectError: `caveat "time-before 2006-01-02T15:04:05.123Z " not fulfilled: parsing time "2006-01-02T15:04:05.123Z ": extra text:  `,
 	}},
+}, {
+	about:   "declared, no entries",
+	checker: checkers.New(checkers.Declared{}),
+	checks: []checkTest{{
+		caveat:      checkers.DeclaredCaveat("a", "aval").Condition,
+		expectError: `caveat "declared a aval" not fulfilled: got a=null, expected "aval"`,
+	}, {
+		caveat:      checkers.CondDeclared,
+		expectError: `caveat "declared" not fulfilled: declared caveat has no value`,
+	}},
+}, {
+	about: "declared, some entries",
+	checker: checkers.New(checkers.Declared{
+		"a":   "aval",
+		"b":   "bval",
+		"spc": " a b",
+	}),
+	checks: []checkTest{{
+		caveat: checkers.DeclaredCaveat("a", "aval").Condition,
+	}, {
+		caveat: checkers.DeclaredCaveat("b", "bval").Condition,
+	}, {
+		caveat: checkers.DeclaredCaveat("spc", " a b").Condition,
+	}, {
+		caveat:      checkers.DeclaredCaveat("a", "bval").Condition,
+		expectError: `caveat "declared a bval" not fulfilled: got a="aval", expected "bval"`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("a", " aval").Condition,
+		expectError: `caveat "declared a  aval" not fulfilled: got a="aval", expected " aval"`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("spc", "a b").Condition,
+		expectError: `caveat "declared spc a b" not fulfilled: got spc=" a b", expected "a b"`,
+	}},
 }}
 
 var errWrongArg = errgo.New("wrong arg")
@@ -195,6 +230,16 @@ func argChecker(expectCond, checkArg string) checkers.Checker {
 	}
 }
 
+func (s *CheckersSuite) TestDeclaredCaveatPanic(c *gc.C) {
+	c.Assert(func() {
+		checkers.DeclaredCaveat("", "hello")
+	}, gc.PanicMatches, `invalid caveat declared key ""`)
+
+	c.Assert(func() {
+		checkers.DeclaredCaveat("some thing", "hello")
+	}, gc.PanicMatches, `invalid caveat declared key "some thing"`)
+}
+
 func (s *CheckersSuite) TestMultiChecker(c *gc.C) {
 	c.Logf("time is %s", now)
 	for i, test := range checkerTests {
@@ -212,5 +257,132 @@ func (s *CheckersSuite) TestMultiChecker(c *gc.C) {
 				c.Assert(err, gc.IsNil)
 			}
 		}
+	}
+}
+
+var inferDeclaredTests = []struct {
+	about   string
+	caveats [][]bakery.Caveat
+	expect  checkers.Declared
+}{{
+	about:  "no macaroons",
+	expect: checkers.Declared{},
+}, {
+	about: "single macaroon with one declaration",
+	caveats: [][]bakery.Caveat{{{
+		Condition: "declared foo bar",
+	}}},
+	expect: checkers.Declared{
+		"foo": "bar",
+	},
+}, {
+	about: "only one argument to declared",
+	caveats: [][]bakery.Caveat{{{
+		Condition: "declared foo",
+	}}},
+	expect: checkers.Declared{},
+}, {
+	about: "spaces in value",
+	caveats: [][]bakery.Caveat{{{
+		Condition: "declared foo bar bloggs",
+	}}},
+	expect: checkers.Declared{
+		"foo": "bar bloggs",
+	},
+}, {
+	about: "attribute with declared prefix",
+	caveats: [][]bakery.Caveat{{{
+		Condition: "declaredccf foo",
+	}}},
+	expect: checkers.Declared{},
+}, {
+	about: "several macaroons with different declares",
+	caveats: [][]bakery.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: checkers.Declared{
+		"a": "aval",
+		"b": "bval",
+		"c": "cval",
+		"d": "dval",
+	},
+}, {
+	about: "duplicate values",
+	caveats: [][]bakery.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: checkers.Declared{
+		"a": "aval",
+		"b": "bval",
+		"c": "cval",
+		"d": "dval",
+	},
+}, {
+	about: "conflicting values",
+	caveats: [][]bakery.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("a", "conflict"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("a", "conflict"),
+		checkers.DeclaredCaveat("b", "another conflict"),
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: checkers.Declared{
+		"c": "cval",
+		"d": "dval",
+	},
+}, {
+	about: "third party caveats ignored",
+	caveats: [][]bakery.Caveat{{{
+		Condition: "declared a no conflict",
+		Location:  "location",
+	},
+		checkers.DeclaredCaveat("a", "aval"),
+	}},
+	expect: checkers.Declared{
+		"a": "aval",
+	},
+}, {
+	about: "unparseable caveats ignored",
+	caveats: [][]bakery.Caveat{{{
+		Condition: " bad",
+	},
+		checkers.DeclaredCaveat("a", "aval"),
+	}},
+	expect: checkers.Declared{
+		"a": "aval",
+	},
+}}
+
+func (*CheckersSuite) TestInferDeclared(c *gc.C) {
+	for i, test := range inferDeclaredTests {
+		c.Logf("test %d: %s", i, test.about)
+		ms := make([]*macaroon.Macaroon, len(test.caveats))
+		for i, caveats := range test.caveats {
+			m, err := macaroon.New(nil, fmt.Sprint(i), "")
+			c.Assert(err, gc.IsNil)
+			for _, cav := range caveats {
+				if cav.Location == "" {
+					m.AddFirstPartyCaveat(cav.Condition)
+				} else {
+					m.AddThirdPartyCaveat(nil, cav.Condition, cav.Location)
+				}
+			}
+			ms[i] = m
+		}
+		c.Assert(checkers.InferDeclared(ms), jc.DeepEquals, test.expect)
 	}
 }

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -1,0 +1,98 @@
+package checkers
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon.v1"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+)
+
+// DeclaredCaveat returns a "declared" caveat asserting that the given key is
+// set to the given value. If a macaroon has exactly one first party
+// caveat asserting the value of a particular key, then InferDeclared
+// will be able to infer the value, and then DeclaredChecker will allow
+// the declared value if it has the value specified here.
+//
+// DeclaredCaveat will panic if the key is empty or contains a space character.
+func DeclaredCaveat(key string, value string) bakery.Caveat {
+	if strings.Contains(key, " ") || key == "" {
+		panic(fmt.Errorf("invalid caveat declared key %q", key))
+	}
+	return firstParty(CondDeclared, key+" "+value)
+}
+
+// Declared implements a checker that will
+// check that any "declared" caveats have a matching
+// key for their value in the map.
+type Declared map[string]string
+
+// Condition implements Checker.Condition.
+func (c Declared) Condition() string {
+	return CondDeclared
+}
+
+// Check implements Checker.Check by checking that the given
+// argument holds a key in the map with a matching value.
+func (c Declared) Check(_, arg string) error {
+	// Note that we don't need to check the condition argument
+	// here because it has been specified explicitly in the
+	// return from the Condition method.
+	parts := strings.SplitN(arg, " ", 2)
+	if len(parts) != 2 {
+		return errgo.Newf("declared caveat has no value")
+	}
+	val, ok := c[parts[0]]
+	if !ok {
+		return errgo.Newf("got %s=null, expected %q", parts[0], parts[1])
+	}
+	if val != parts[1] {
+		return errgo.Newf("got %s=%q, expected %q", parts[0], val, parts[1])
+	}
+	return nil
+}
+
+// InferDeclared retrieves any declared information from
+// the given macaroons and returns it as a key-value map.
+//
+// Information is declared with a first party caveat as created
+// by DeclaredCaveat.
+//
+// If there are two caveats that declare the same key with
+// different values, the information is omitted from the map.
+// When the caveats are later checked, this will cause the
+// check to fail.
+func InferDeclared(ms []*macaroon.Macaroon) Declared {
+	var conflicts []string
+	info := make(Declared)
+	for _, m := range ms {
+		for _, cav := range m.Caveats() {
+			if cav.Location != "" {
+				continue
+			}
+			name, rest, err := ParseCaveat(cav.Id)
+			if err != nil {
+				continue
+			}
+			if name != CondDeclared {
+				continue
+			}
+			parts := strings.SplitN(rest, " ", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			key, val := parts[0], parts[1]
+			if oldVal, ok := info[key]; ok && oldVal != val {
+				conflicts = append(conflicts, key)
+				continue
+			}
+			info[key] = val
+		}
+	}
+	for _, key := range conflicts {
+		delete(info, key)
+	}
+	return info
+}

--- a/bakery/checkers/time.go
+++ b/bakery/checkers/time.go
@@ -14,7 +14,7 @@ var timeNow = time.Now
 // TimeBefore is a checker that checks caveats
 // as created by TimeBeforeCaveat.
 var TimeBefore = CheckerFunc{
-	Condition_: "time-before",
+	Condition_: CondTimeBefore,
 	Check_: func(_, cav string) error {
 		t, err := time.Parse(time.RFC3339Nano, cav)
 		if err != nil {
@@ -30,5 +30,5 @@ var TimeBefore = CheckerFunc{
 // TimeBeforeCaveat returns a caveat that specifies that
 // the time that it is checked should be before t.
 func TimeBeforeCaveat(t time.Time) bakery.Caveat {
-	return firstParty(TimeBefore.Condition(), t.UTC().Format(time.RFC3339Nano))
+	return firstParty(CondTimeBefore, t.UTC().Format(time.RFC3339Nano))
 }


### PR DESCRIPTION
This allows macaroons to declare information by adding a first-party
caveat. The declarations inferred are valid after caveat checking because
we guarantee to check all discharge macaroons when verifying. A client can
add another declaration caveat, but they can't change the value of an existing
declaration.

To come: built in support for third party caveats that require a set of
declarations to be added when discharged.
