### PR TITLE
httpbakery: add HTTP checker

### DIFF
--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -1,7 +1,6 @@
 package checkers
 
 import (
-	"fmt"
 	"strings"
 
 	"gopkg.in/errgo.v1"
@@ -16,10 +15,11 @@ import (
 // will be able to infer the value, and then DeclaredChecker will allow
 // the declared value if it has the value specified here.
 //
-// DeclaredCaveat will panic if the key is empty or contains a space character.
+// If the key is empty or contains a space, DeclaredCaveat
+// will return an error caveat.
 func DeclaredCaveat(key string, value string) bakery.Caveat {
 	if strings.Contains(key, " ") || key == "" {
-		panic(fmt.Errorf("invalid caveat declared key %q", key))
+		return ErrorCaveatf("invalid caveat 'declared' key %q", key)
 	}
 	return firstParty(CondDeclared, key+" "+value)
 }

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -1,0 +1,71 @@
+package httpbakery
+
+import (
+	"net"
+	"net/http"
+
+	"gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+)
+
+type httpContext struct {
+	req *http.Request
+}
+
+// Checkers implements the standard HTTP-request checkers.
+// It does not include the "declared" checker, as that
+// must be added for each individual set of macaroons
+// that are checked.
+func Checkers(req *http.Request) checkers.Checker {
+	c := httpContext{req}
+	return checkers.Map{
+		checkers.CondClientIPAddr: c.clientIPAddr,
+	}
+}
+
+// clientIPAddr implements the IP client address checker
+// for an HTTP request.
+func (c httpContext) clientIPAddr(_, addr string) error {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return errgo.Newf("cannot parse IP address in caveat")
+	}
+	if c.req.RemoteAddr == "" {
+		return errgo.Newf("client has no remote address")
+	}
+	reqIP, err := requestIPAddr(c.req)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	if !reqIP.Equal(ip) {
+		return errgo.Newf("client IP address mismatch, got %s", reqIP)
+	}
+	return nil
+}
+
+// SameClientIPAddrCaveat returns a caveat that will check that
+// the remote IP address is the same as that in the given HTTP request.
+func SameClientIPAddrCaveat(req *http.Request) bakery.Caveat {
+	if req.RemoteAddr == "" {
+		return checkers.ErrorCaveatf("client has no remote IP address")
+	}
+	ip, err := requestIPAddr(req)
+	if err != nil {
+		return checkers.ErrorCaveatf("%v", err)
+	}
+	return checkers.ClientIPAddrCaveat(ip)
+}
+
+func requestIPAddr(req *http.Request) (net.IP, error) {
+	reqHost, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return nil, errgo.Newf("cannot parse host port in remote address: %v", err)
+	}
+	ip := net.ParseIP(reqHost)
+	if ip == nil {
+		return nil, errgo.Newf("invalid IP address in remote address %q", req.RemoteAddr)
+	}
+	return ip, nil
+}

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -1,0 +1,149 @@
+package httpbakery_test
+
+import (
+	"net"
+	"net/http"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
+)
+
+type CheckersSuite struct{}
+
+var _ = gc.Suite(&CheckersSuite{})
+
+type checkTest struct {
+	caveat      string
+	expectError string
+	expectCause func(err error) bool
+}
+
+var isCaveatNotRecognized = errgo.Is(bakery.ErrCaveatNotRecognized)
+
+var checkerTests = []struct {
+	about   string
+	checker checkers.Checker
+	checks  []checkTest
+}{{
+	about:   "no host name declared",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{})),
+	checks: []checkTest{{
+		caveat:      checkers.ClientIPAddrCaveat(net.IP{0, 0, 0, 0}).Condition,
+		expectError: `caveat "client-ip-addr 0.0.0.0" not satisfied: client has no remote address`,
+	}, {
+		caveat:      checkers.ClientIPAddrCaveat(net.IP{127, 0, 0, 1}).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.1" not satisfied: client has no remote address`,
+	}, {
+		caveat:      "client-ip-addr badip",
+		expectError: `caveat "client-ip-addr badip" not satisfied: cannot parse IP address in caveat`,
+	}},
+}, {
+	about: "IPv4 host name declared",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{
+		RemoteAddr: "127.0.0.1:1234",
+	})),
+	checks: []checkTest{{
+		caveat: checkers.ClientIPAddrCaveat(net.IP{127, 0, 0, 1}).Condition,
+	}, {
+		caveat: checkers.ClientIPAddrCaveat(net.IP{127, 0, 0, 1}.To16()).Condition,
+	}, {
+		caveat: "client-ip-addr ::ffff:7f00:1",
+	}, {
+		caveat:      checkers.ClientIPAddrCaveat(net.IP{127, 0, 0, 2}).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.2" not satisfied: client IP address mismatch, got 127.0.0.1`,
+	}, {
+		caveat:      checkers.ClientIPAddrCaveat(net.ParseIP("2001:4860:0:2001::68")).Condition,
+		expectError: `caveat "client-ip-addr 2001:4860:0:2001::68" not satisfied: client IP address mismatch, got 127.0.0.1`,
+	}},
+}, {
+	about: "IPv6 host name declared",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{
+		RemoteAddr: "[2001:4860:0:2001::68]:1234",
+	})),
+	checks: []checkTest{{
+		caveat: checkers.ClientIPAddrCaveat(net.ParseIP("2001:4860:0:2001::68")).Condition,
+	}, {
+		caveat: "client-ip-addr 2001:4860:0:2001:0::68",
+	}, {
+		caveat:      checkers.ClientIPAddrCaveat(net.ParseIP("2001:4860:0:2001::69")).Condition,
+		expectError: `caveat "client-ip-addr 2001:4860:0:2001::69" not satisfied: client IP address mismatch, got 2001:4860:0:2001::68`,
+	}, {
+		caveat:      checkers.ClientIPAddrCaveat(net.ParseIP("127.0.0.1")).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.1" not satisfied: client IP address mismatch, got 2001:4860:0:2001::68`,
+	}},
+}, {
+	about: "same client address, ipv4 request address",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{
+		RemoteAddr: "127.0.0.1:1324",
+	})),
+	checks: []checkTest{{
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "127.0.0.1:1234",
+		}).Condition,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "[::ffff:7f00:1]:1235",
+		}).Condition,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "127.0.0.2:1234",
+		}).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.2" not satisfied: client IP address mismatch, got 127.0.0.1`,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "[::ffff:7f00:2]:1235",
+		}).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.2" not satisfied: client IP address mismatch, got 127.0.0.1`,
+	}, {
+		caveat:      httpbakery.SameClientIPAddrCaveat(&http.Request{}).Condition,
+		expectError: `caveat "error client has no remote IP address" not satisfied: bad caveat`,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "bad",
+		}).Condition,
+		expectError: `caveat "error cannot parse host port in remote address: missing port in address bad" not satisfied: bad caveat`,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "bad:56",
+		}).Condition,
+		expectError: `caveat "error invalid IP address in remote address \\"bad:56\\"" not satisfied: bad caveat`,
+	}},
+}, {
+	about: "same client address, ipv6 request address",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{
+		RemoteAddr: "[2001:4860:0:2001:0::68]:1235",
+	})),
+	checks: []checkTest{{
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "[2001:4860:0:2001:0::68]:1234",
+		}).Condition,
+	}, {
+		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
+			RemoteAddr: "127.0.0.2:1234",
+		}).Condition,
+		expectError: `caveat "client-ip-addr 127.0.0.2" not satisfied: client IP address mismatch, got 2001:4860:0:2001::68`,
+	}},
+}}
+
+func (s *CheckersSuite) TestCheckers(c *gc.C) {
+	for i, test := range checkerTests {
+		c.Logf("test %d: %s", i, test.about)
+		for j, check := range test.checks {
+			c.Logf("\tcheck %d", j)
+			err := checkers.New(test.checker).CheckFirstPartyCaveat(check.caveat)
+			if check.expectError != "" {
+				c.Assert(err, gc.ErrorMatches, check.expectError)
+				if check.expectCause == nil {
+					check.expectCause = errgo.Any
+				}
+				c.Assert(check.expectCause(errgo.Cause(err)), gc.Equals, true)
+			} else {
+				c.Assert(err, gc.IsNil)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This will be standard to use in HTTP-based servers.
Also add a single caveat, client-ip-addr and a checker
for that, and a function that can create that from an
existing request.

We also introduce an "error" caveat, which can never be
satisfied, but makes it easy to create caveats from possibly-but-very-rarely-invalid
data without adding lots of error checking. When the caveat
is checked, the error from the check will reflect the orginal
error when the caveat was created.
