### PR TITLE
bakery: implement CheckAny

### DIFF
--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -402,7 +402,7 @@ var inferDeclaredTests = []struct {
 func (*CheckersSuite) TestInferDeclared(c *gc.C) {
 	for i, test := range inferDeclaredTests {
 		c.Logf("test %d: %s", i, test.about)
-		ms := make([]*macaroon.Macaroon, len(test.caveats))
+		ms := make(macaroon.Slice, len(test.caveats))
 		for i, caveats := range test.caveats {
 			m, err := macaroon.New(nil, fmt.Sprint(i), "")
 			c.Assert(err, gc.IsNil)

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -62,7 +62,7 @@ func (c Declared) Check(_, arg string) error {
 // different values, the information is omitted from the map.
 // When the caveats are later checked, this will cause the
 // check to fail.
-func InferDeclared(ms []*macaroon.Macaroon) Declared {
+func InferDeclared(ms macaroon.Slice) Declared {
 	var conflicts []string
 	info := make(Declared)
 	for _, m := range ms {

--- a/bakery/codec.go
+++ b/bakery/codec.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-
 	"code.google.com/p/go.crypto/nacl/box"
+
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
 )
 
 type caveatIdRecord struct {

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -16,9 +16,9 @@ import (
 func DischargeAll(
 	m *macaroon.Macaroon,
 	getDischarge func(firstPartyLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error),
-) ([]*macaroon.Macaroon, error) {
+) (macaroon.Slice, error) {
 	sig := m.Signature()
-	discharges := []*macaroon.Macaroon{m}
+	discharges := macaroon.Slice{m}
 	var need []macaroon.Caveat
 	addCaveats := func(m *macaroon.Macaroon) {
 		for _, cav := range m.Caveats() {

--- a/bakery/example/idservice/idservice.go
+++ b/bakery/example/idservice/idservice.go
@@ -71,7 +71,7 @@ func New(p Params) (http.Handler, error) {
 // It is only accessible to users that are members of the admin group.
 func (h *handler) userHandler(_ http.Header, req *http.Request) (interface{}, error) {
 	ctxt := h.newContext(req, "change-user")
-	if _, err := httpbakery.CheckRequest(h.svc, req, ctxt, nil); err != nil {
+	if _, err := httpbakery.CheckRequest(h.svc, req, nil, ctxt); err != nil {
 		// TODO do this only if the error cause is *bakery.VerificationError
 		// We issue a macaroon with a third-party caveat targetting
 		// the id service itself. This means that the flow for self-created
@@ -174,7 +174,7 @@ func (h *handler) loginAttemptHandler(w http.ResponseWriter, req *http.Request) 
 		http.Error(w, "cannot mint macaroon: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	cookie, err := httpbakery.NewCookie([]*macaroon.Macaroon{m})
+	cookie, err := httpbakery.NewCookie(macaroon.Slice{m})
 	if err != nil {
 		http.Error(w, "cannot make cookie: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -429,7 +429,7 @@ func (ctxt *context) canSpeakFor(user string) error {
 	}
 	ctxt1 := *ctxt
 	ctxt1.declaredUser = user
-	_, err := httpbakery.CheckRequest(ctxt.svc, ctxt.req, &ctxt1, nil)
+	_, err := httpbakery.CheckRequest(ctxt.svc, ctxt.req, nil, &ctxt1)
 	if err != nil {
 		log.Printf("client cannot speak for %q: %v", user, err)
 	} else {

--- a/bakery/example/idservice/targetservice_test.go
+++ b/bakery/example/idservice/targetservice_test.go
@@ -50,7 +50,7 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 
 func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Request) {
 	checker := srv.checkers(req, "gold")
-	if _, err := httpbakery.CheckRequest(srv.svc, req, checker, nil); err != nil {
+	if _, err := httpbakery.CheckRequest(srv.svc, req, nil, checker); err != nil {
 		srv.writeError(w, "gold", err)
 		return
 	}
@@ -59,7 +59,7 @@ func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Requ
 
 func (srv *targetServiceHandler) serveSilver(w http.ResponseWriter, req *http.Request) {
 	checker := srv.checkers(req, "silver")
-	if _, err := httpbakery.CheckRequest(srv.svc, req, checker, nil); err != nil {
+	if _, err := httpbakery.CheckRequest(srv.svc, req, nil, checker); err != nil {
 		srv.writeError(w, "silver", err)
 		return
 	}

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -52,7 +52,7 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 
 func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Request) {
 	checker := srv.checkers(req, "gold")
-	if _, err := httpbakery.CheckRequest(srv.svc, req, checker, nil); err != nil {
+	if _, err := httpbakery.CheckRequest(srv.svc, req, nil, checker); err != nil {
 		srv.writeError(w, "gold", err)
 		return
 	}
@@ -61,7 +61,7 @@ func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Requ
 
 func (srv *targetServiceHandler) serveSilver(w http.ResponseWriter, req *http.Request) {
 	checker := srv.checkers(req, "silver")
-	if _, err := httpbakery.CheckRequest(srv.svc, req, checker, nil); err != nil {
+	if _, err := httpbakery.CheckRequest(srv.svc, req, nil, checker); err != nil {
 		srv.writeError(w, "silver", err)
 		return
 	}

--- a/bakery/mgostorage/storage_test.go
+++ b/bakery/mgostorage/storage_test.go
@@ -127,6 +127,6 @@ func (s *StorageSuite) TestCreateMacaroon(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(item, gc.DeepEquals, `{"RootKey":"YWJj"}`)
 
-	err = service.Check([]*macaroon.Macaroon{m}, &testChecker{})
+	err = service.Check(macaroon.Slice{m}, &testChecker{})
 	c.Assert(err, gc.IsNil)
 }

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -39,7 +39,7 @@ func (s *ServiceSuite) TestSingleServiceFirstParty(c *gc.C) {
 	err = service.AddCaveat(primary, cav)
 	c.Assert(err, gc.IsNil)
 
-	err = service.Check([]*macaroon.Macaroon{primary}, strCompFirstPartyChecker("something"))
+	err = service.Check(macaroon.Slice{primary}, strCompFirstPartyChecker("something"))
 	c.Assert(err, gc.IsNil)
 }
 
@@ -98,7 +98,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithoutDischarges(c *gc.C) {
 	tsMacaroon := createMacaroonWithThirdPartyCaveat(c, ts, fs, checkers.Caveat{Location: "as-loc", Condition: "user==bob"})
 
 	// client makes request to ts
-	err := ts.Check([]*macaroon.Macaroon{tsMacaroon}, strCompFirstPartyChecker(""))
+	err := ts.Check(macaroon.Slice{tsMacaroon}, strCompFirstPartyChecker(""))
 	c.Assert(err, gc.ErrorMatches, `verification failed: cannot find discharge macaroon for caveat ".*"`)
 }
 

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -7,7 +7,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
 	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v0/httpbakery"
 )

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -42,7 +42,7 @@ func (s *ClientSuite) TestSingleServiceFirstParty(c *gc.C) {
 	// Create a client request.
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	c.Assert(err, gc.IsNil)
-	client := clientRequestWithCookies(c, ts.URL, []*macaroon.Macaroon{serverMacaroon})
+	client := clientRequestWithCookies(c, ts.URL, macaroon.Slice{serverMacaroon})
 	// Somehow the client has accquired the macaroon. Add it to the cookiejar in our request.
 
 	// Make the request to the server.
@@ -77,7 +77,7 @@ func newServer(h func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-func clientRequestWithCookies(c *gc.C, u string, macaroons []*macaroon.Macaroon) *http.Client {
+func clientRequestWithCookies(c *gc.C, u string, macaroons macaroon.Slice) *http.Client {
 	client := httpbakery.DefaultHTTPClient
 	url, err := url.Parse(u)
 	c.Assert(err, gc.IsNil)
@@ -88,7 +88,7 @@ func clientRequestWithCookies(c *gc.C, u string, macaroons []*macaroon.Macaroon)
 
 func serverHandler(service *bakery.Service) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		if _, err := httpbakery.CheckRequest(service, req, isChecker("something"), nil); err != nil {
+		if _, err := httpbakery.CheckRequest(service, req, nil, isChecker("something")); err != nil {
 			http.Error(w, "no macaroon", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Factor CheckAny out from httpbakery.Check. There's no
new behaviour here.

Also (and trivial) rewrite []*macaroon.Macaroon to macaroon.Slice throughout
and change the argument order of httpbakery.Check.
