### PR TITLE
bakerytest: new package

### DIFF
--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -1,0 +1,75 @@
+// Package bakerytest provides test helper functions for
+// the bakery.
+package bakerytest
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
+)
+
+// Discharger is a third-party caveat discharger suitable
+// for testing. It listens on a local network port for
+// discharge requests. It should be shut down by calling
+// Close when done with.
+type Discharger struct {
+	Service *bakery.Service
+
+	server *httptest.Server
+}
+
+// NewDischarger returns a new third party caveat discharger
+// which uses the given function to check caveats.
+// The cond and arg arguments to the function are as returned
+// by checkers.ParseCaveat.
+//
+// If locator is non-nil, it will be used to find public keys
+// for any third party caveats returned by the checker.
+func NewDischarger(
+	locator bakery.PublicKeyLocator,
+	checker func(cond, arg string) ([]checkers.Caveat, error),
+) *Discharger {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	svc, err := bakery.NewService(bakery.NewServiceParams{
+		Location: server.URL,
+		Locator:  locator,
+	})
+	if err != nil {
+		panic(err)
+	}
+	checker1 := func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+		cond, arg, err := checkers.ParseCaveat(cav)
+		if err != nil {
+			return nil, err
+		}
+		return checker(cond, arg)
+	}
+	httpbakery.AddDischargeHandler(mux, "/", svc, checker1)
+	return &Discharger{
+		Service: svc,
+		server:  server,
+	}
+}
+
+// Close shuts down the server.
+func (d *Discharger) Close() {
+	d.server.Close()
+}
+
+// Location returns the location of the discharger, suitable
+// for setting as the location in a third party caveat.
+func (d *Discharger) Location() string {
+	return d.Service.Location()
+}
+
+// PublicKeyForLocation implements bakery.PublicKeyLocator.
+func (d *Discharger) PublicKeyForLocation(loc string) (*bakery.PublicKey, error) {
+	if loc == d.Location() {
+		return d.Service.PublicKey(), nil
+	}
+	return nil, bakery.ErrNotFound
+}

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -1,0 +1,102 @@
+package bakerytest_test
+
+import (
+	"fmt"
+	"net/url"
+
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v0/bakerytest"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func noCaveatChecker(cond, arg string) ([]checkers.Caveat, error) {
+	return nil, nil
+}
+
+func (*suite) TestDischargerSimple(c *gc.C) {
+	d := bakerytest.NewDischarger(nil, noCaveatChecker)
+	defer d.Close()
+
+	svc, err := bakery.NewService(bakery.NewServiceParams{
+		Location: "here",
+		Locator:  d,
+	})
+	c.Assert(err, gc.IsNil)
+	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		Location:  d.Location(),
+		Condition: "something",
+	}})
+	c.Assert(err, gc.IsNil)
+	ms, err := httpbakery.DischargeAll(m, httpbakery.DefaultHTTPClient, noInteraction)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	err = svc.Check(ms, failChecker)
+	c.Assert(err, gc.IsNil)
+}
+
+var failChecker = bakery.FirstPartyCheckerFunc(func(s string) error {
+	return fmt.Errorf("fail %s", s)
+})
+
+func (*suite) TestDischargerTwoLevels(c *gc.C) {
+	d1checker := func(cond, arg string) ([]checkers.Caveat, error) {
+		if cond != "xtrue" {
+			return nil, fmt.Errorf("caveat refused")
+		}
+		return nil, nil
+	}
+	d1 := bakerytest.NewDischarger(nil, d1checker)
+	defer d1.Close()
+	d2checker := func(cond, arg string) ([]checkers.Caveat, error) {
+		return []checkers.Caveat{{
+			Location:  d1.Location(),
+			Condition: "x" + cond,
+		}}, nil
+	}
+	d2 := bakerytest.NewDischarger(d1, d2checker)
+	defer d2.Close()
+	locator := bakery.PublicKeyLocatorMap{
+		d1.Location(): d1.Service.PublicKey(),
+		d2.Location(): d2.Service.PublicKey(),
+	}
+	c.Logf("map: %s", locator)
+	svc, err := bakery.NewService(bakery.NewServiceParams{
+		Location: "here",
+		Locator:  locator,
+	})
+	c.Assert(err, gc.IsNil)
+	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		Location:  d2.Location(),
+		Condition: "true",
+	}})
+	c.Assert(err, gc.IsNil)
+
+	ms, err := httpbakery.DischargeAll(m, httpbakery.DefaultHTTPClient, noInteraction)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ms, gc.HasLen, 3)
+
+	err = svc.Check(ms, failChecker)
+	c.Assert(err, gc.IsNil)
+
+	err = svc.AddCaveat(m, checkers.Caveat{
+		Location:  d2.Location(),
+		Condition: "nope",
+	})
+	c.Assert(err, gc.IsNil)
+
+	ms, err = httpbakery.DischargeAll(m, httpbakery.DefaultHTTPClient, noInteraction)
+	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "http://[^"]*": cannot discharge: caveat refused`)
+	c.Assert(ms, gc.HasLen, 0)
+}
+
+func noInteraction(*url.URL) error {
+	return fmt.Errorf("unexpected interaction required")
+}

--- a/bakerytest/package_test.go
+++ b/bakerytest/package_test.go
@@ -1,0 +1,11 @@
+package bakerytest_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This should make it simpler to test services that issue macaroons.

Also add httpbakery.DischargeAll to make it possible to use
the httpbakery discharge machinery without going through
httpbakery.Do.
