### PR TITLE
bakery: add support for need-declared third party caveat

### DIFF
--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -11,11 +11,14 @@ import (
 )
 
 // Constants for all the standard caveat conditions.
+// First and third party caveat conditions are both defined here,
+// even though notionally they exist in separate name spaces.
 const (
 	CondDeclared     = "declared"
 	CondTimeBefore   = "time-before"
 	CondClientIPAddr = "client-ip-addr"
 	CondError        = "error"
+	CondNeedDeclared = "need-declared"
 )
 
 // ErrCaveatNotRecognized is the cause of errors returned

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -22,6 +22,20 @@ func DeclaredCaveat(key string, value string) Caveat {
 	return firstParty(CondDeclared, key+" "+value)
 }
 
+// NeedDeclaredCaveat returns a third party caveat that
+// wraps the provided third party caveat and requires
+// that the third party must add "declared" caveats for
+// all the named keys.
+func NeedDeclaredCaveat(cav Caveat, keys ...string) Caveat {
+	if cav.Location == "" {
+		return ErrorCaveatf("need-declared caveat is not third-party")
+	}
+	return Caveat{
+		Location: cav.Location,
+		Condition: CondNeedDeclared +  " " + strings.Join(keys, ",") + " " + cav.Condition,
+	}
+}
+
 // Declared implements a checker that will
 // check that any "declared" caveats have a matching
 // key for their value in the map.


### PR DESCRIPTION
This makes it possible to add a third-party caveat that requires
some declared caveats and be assured that (as long as they're
using the bakery package) they will be added.
