### PR TITLE
httpbakery: remove DefaultHTTPClient variable

### DIFF
--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -15,7 +15,7 @@ import (
 // In this simple example, it just tries a GET
 // request, which will fail unless the client
 // has the required authorization.
-func clientRequest(serverEndpoint string) (string, error) {
+func clientRequest(httpClient *http.Client, serverEndpoint string) (string, error) {
 	req, err := http.NewRequest("GET", serverEndpoint, nil)
 	if err != nil {
 		return "", errgo.Notef(err, "cannot make new HTTP request")
@@ -30,7 +30,7 @@ func clientRequest(serverEndpoint string) (string, error) {
 		fmt.Printf("\t%s\n", url)
 		return nil
 	}
-	resp, err := httpbakery.Do(httpbakery.DefaultHTTPClient, req, visitWebPage)
+	resp, err := httpbakery.Do(httpClient, req, visitWebPage)
 	if err != nil {
 		return "", errgo.NoteMask(err, "GET failed", errgo.Any)
 	}

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -7,6 +7,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
 )
 
 func TestPackage(t *testing.T) {
@@ -31,29 +32,31 @@ func (s *exampleSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *exampleSuite) TestExample(c *gc.C) {
+	httpClient := httpbakery.NewHTTPClient()
 	serverEndpoint, err := serve(func(endpoint string) (http.Handler, error) {
 		return targetService(endpoint, s.authEndpoint, s.authPublicKey)
 	})
 	c.Assert(err, gc.IsNil)
 	c.Logf("gold request")
-	resp, err := clientRequest(serverEndpoint + "/gold")
+	resp, err := clientRequest(httpClient, serverEndpoint+"/gold")
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "all is golden")
 
 	c.Logf("silver request")
-	resp, err = clientRequest(serverEndpoint + "/silver")
+	resp, err = clientRequest(httpClient, serverEndpoint+"/silver")
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "every cloud has a silver lining")
 }
 
 func (s *exampleSuite) BenchmarkExample(c *gc.C) {
+	httpClient := httpbakery.NewHTTPClient()
 	serverEndpoint, err := serve(func(endpoint string) (http.Handler, error) {
 		return targetService(endpoint, s.authEndpoint, s.authPublicKey)
 	})
 	c.Assert(err, gc.IsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		resp, err := clientRequest(serverEndpoint)
+		resp, err := clientRequest(httpClient, serverEndpoint)
 		c.Assert(err, gc.IsNil)
 		c.Assert(resp, gc.Equals, "hello, world\n")
 	}

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -24,7 +24,10 @@ import (
 	"net/http"
 
 	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
 )
+
+var defaultHTTPClient = httpbakery.NewHTTPClient()
 
 func main() {
 	key, err := bakery.GenerateKey()
@@ -38,7 +41,7 @@ func main() {
 	serverEndpoint := mustServe(func(endpoint string) (http.Handler, error) {
 		return targetService(endpoint, authEndpoint, authPublicKey)
 	})
-	resp, err := clientRequest(serverEndpoint)
+	resp, err := clientRequest(defaultHTTPClient, serverEndpoint)
 	if err != nil {
 		log.Fatalf("client failed: %v", err)
 	}

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -20,12 +20,13 @@ import (
 	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
 )
 
-// DefaultHTTPClient is an http.Client that ensures that
-// headers are sent to the server even when the server redirects.
+// NewHTTPClient returns an http.Client that ensures
+// that headers are sent to the server even when the
+// server redirects a GET request. The returned client
+// also contains an empty in-memory cookie jar.
+//
 // See https://github.com/golang/go/issues/4677
-var DefaultHTTPClient = defaultHTTPClient()
-
-func defaultHTTPClient() *http.Client {
+func NewHTTPClient() *http.Client {
 	c := *http.DefaultClient
 	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -78,7 +78,7 @@ func newServer(h func(http.ResponseWriter, *http.Request)) *httptest.Server {
 }
 
 func clientRequestWithCookies(c *gc.C, u string, macaroons macaroon.Slice) *http.Client {
-	client := httpbakery.DefaultHTTPClient
+	client := httpbakery.NewHTTPClient()
 	url, err := url.Parse(u)
 	c.Assert(err, gc.IsNil)
 	err = httpbakery.SetCookie(client.Jar, url, macaroons)


### PR DESCRIPTION
It is too easy to abuse, and it's easy to create an appropriate client
when needed. We replace it with the NewHTTPClient function
which does not have the same issue with mutable global state.
