### PR TITLE
bakery: add support for self-discharged 3rd party caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ It holds higher level operations for building systems with macaroons.
 
 For documentation, see:
 
-- http://godoc.org/gopkg.in/macaroon-bakery.v0/bakery
-- http://godoc.org/gopkg.in/macaroon-bakery.v0/httpbakery
-- http://godoc.org/gopkg.in/macaroon-bakery.v0/bakery/checkers
+- http://godoc.org/gopkg.in/macaroon-bakery.v1/bakery
+- http://godoc.org/gopkg.in/macaroon-bakery.v1/httpbakery
+- http://godoc.org/gopkg.in/macaroon-bakery.v1/bakery/checkers

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -10,8 +10,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type CheckersSuite struct{}

--- a/bakery/codec.go
+++ b/bakery/codec.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/crypto/nacl/box"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type caveatIdRecord struct {

--- a/bakery/codec.go
+++ b/bakery/codec.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 
 	"golang.org/x/crypto/nacl/box"
-
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type caveatIdRecord struct {
@@ -28,28 +26,19 @@ type caveatId struct {
 // boxEncoder encodes caveat ids confidentially to a third-party service using
 // authenticated public key encryption compatible with NaCl box.
 type boxEncoder struct {
-	locator PublicKeyLocator
-	key     *KeyPair
+	key *KeyPair
 }
 
 // newBoxEncoder creates a new boxEncoder with the given public key pair and
 // third-party public key locator function.
-func newBoxEncoder(locator PublicKeyLocator, key *KeyPair) *boxEncoder {
+func newBoxEncoder(key *KeyPair) *boxEncoder {
 	return &boxEncoder{
-		key:     key,
-		locator: locator,
+		key: key,
 	}
 }
 
-func (enc *boxEncoder) encodeCaveatId(cav checkers.Caveat, rootKey []byte) (string, error) {
-	if cav.Location == "" {
-		return "", fmt.Errorf("cannot make caveat id for first party caveat")
-	}
-	thirdPartyPub, err := enc.locator.PublicKeyForLocation(cav.Location)
-	if err != nil {
-		return "", err
-	}
-	id, err := enc.newCaveatId(cav, rootKey, thirdPartyPub)
+func (enc *boxEncoder) encodeCaveatId(condition string, rootKey []byte, thirdPartyPub *PublicKey) (string, error) {
+	id, err := enc.newCaveatId(condition, rootKey, thirdPartyPub)
 	if err != nil {
 		return "", err
 	}
@@ -60,14 +49,14 @@ func (enc *boxEncoder) encodeCaveatId(cav checkers.Caveat, rootKey []byte) (stri
 	return base64.StdEncoding.EncodeToString(data), nil
 }
 
-func (enc *boxEncoder) newCaveatId(cav checkers.Caveat, rootKey []byte, thirdPartyPub *PublicKey) (*caveatId, error) {
+func (enc *boxEncoder) newCaveatId(condition string, rootKey []byte, thirdPartyPub *PublicKey) (*caveatId, error) {
 	var nonce [NonceLen]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return nil, fmt.Errorf("cannot generate random number for nonce: %v", err)
 	}
 	plain := caveatIdRecord{
 		RootKey:   rootKey,
-		Condition: cav.Condition,
+		Condition: condition,
 	}
 	plainData, err := json.Marshal(&plain)
 	if err != nil {

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -5,6 +5,8 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
+
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 // DischargeAll gathers discharge macaroons for all the third party caveats
@@ -13,9 +15,18 @@ import (
 // It returns a slice with m as the first element, followed by
 // all the discharge macaroons. All the discharge macaroons
 // will be bound to the primary macaroon.
+//
+// The selfKey parameter may optionally hold the
+// key of the client, in which case it will be used
+// to discharge any third party caveats with the
+// special location "self". In this case, the caveat
+// itself must be "true". This can be used be
+// a server to ask a client to prove ownership
+// of the private key.
 func DischargeAll(
 	m *macaroon.Macaroon,
 	getDischarge func(firstPartyLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error),
+	selfKey *KeyPair,
 ) (macaroon.Slice, error) {
 	sig := m.Signature()
 	discharges := macaroon.Slice{m}
@@ -33,7 +44,13 @@ func DischargeAll(
 	for len(need) > 0 {
 		cav := need[0]
 		need = need[1:]
-		dm, err := getDischarge(firstPartyLocation, cav)
+		var dm *macaroon.Macaroon
+		var err error
+		if selfKey != nil && cav.Location == "self" {
+			dm, _, err = Discharge(selfKey, selfDischargeChecker, cav.Id)
+		} else {
+			dm, err = getDischarge(firstPartyLocation, cav)
+		}
 		if err != nil {
 			return nil, errgo.NoteMask(err, fmt.Sprintf("cannot get discharge from %q", cav.Location), errgo.Any)
 		}
@@ -43,3 +60,10 @@ func DischargeAll(
 	}
 	return discharges, nil
 }
+
+var selfDischargeChecker = ThirdPartyCheckerFunc(func(caveatId, caveat string) ([]checkers.Caveat, *PublicKey, error) {
+	if caveat != "true" {
+		return nil, nil, checkers.ErrCaveatNotRecognized
+	}
+	return nil, nil, nil
+})

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -6,7 +6,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 type DischargeSuite struct{}

--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -31,13 +31,13 @@ func authService(endpoint string, key *bakery.KeyPair) (http.Handler, error) {
 //
 // Note how this function can return additional first- and third-party
 // caveats which will be added to the original macaroon's caveats.
-func thirdPartyChecker(req *http.Request, cavId, condition string) ([]checkers.Caveat, error) {
+func thirdPartyChecker(req *http.Request, cavId, condition string) ([]checkers.Caveat, *bakery.PublicKey, error) {
 	if condition != "access-allowed" {
-		return nil, checkers.ErrCaveatNotRecognized
+		return nil, nil, checkers.ErrCaveatNotRecognized
 	}
 	// TODO check that the HTTP request has cookies that prove
 	// something about the client.
 	return []checkers.Caveat{
 		httpbakery.SameClientIPAddrCaveat(req),
-	}, nil
+	}, nil, nil
 }

--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 // authService implements an authorization service,

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -8,7 +8,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 // client represents a client of the target service.

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"gopkg.in/errgo.v1"
 
@@ -15,21 +14,14 @@ import (
 // In this simple example, it just tries a GET
 // request, which will fail unless the client
 // has the required authorization.
-func clientRequest(httpClient *http.Client, serverEndpoint string) (string, error) {
-	req, err := http.NewRequest("GET", serverEndpoint, nil)
-	if err != nil {
-		return "", errgo.Notef(err, "cannot make new HTTP request")
-	}
+func clientRequest(client *httpbakery.Client, serverEndpoint string) (string, error) {
 	// The Do function implements the mechanics
 	// of actually gathering discharge macaroons
 	// when required, and retrying the request
 	// when necessary.
-
-	client := httpbakery.NewClient()
-	client.VisitWebPage = func(url *url.URL) error {
-		fmt.Printf("please visit this web page:\n")
-		fmt.Printf("\t%s\n", url)
-		return nil
+	req, err := http.NewRequest("GET", serverEndpoint, nil)
+	if err != nil {
+		return "", errgo.Notef(err, "cannot make new HTTP request")
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -6,8 +6,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 func TestPackage(t *testing.T) {

--- a/bakery/example/idservice/idservice.go
+++ b/bakery/example/idservice/idservice.go
@@ -10,10 +10,10 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/bakery/example/meeting"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 var (

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -13,9 +13,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/example/idservice"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/example/idservice"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type suite struct {

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -89,10 +89,6 @@ func (s *suite) TestIdService(c *gc.C) {
 	c.Assert(resp, gc.Equals, "every cloud has a silver lining")
 }
 
-func noVisit(*url.URL) error {
-	return errgo.New("should not be visiting")
-}
-
 func serve(c *gc.C, newHandler func(string) (http.Handler, error)) (endpointURL string) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, gc.IsNil)

--- a/bakery/example/idservice/meeting.go
+++ b/bakery/example/idservice/meeting.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
 )
 
 type thirdPartyCaveatInfo struct {

--- a/bakery/example/idservice/targetservice_test.go
+++ b/bakery/example/idservice/targetservice_test.go
@@ -7,9 +7,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type targetServiceHandler struct {

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -41,7 +41,7 @@ func main() {
 	serverEndpoint := mustServe(func(endpoint string) (http.Handler, error) {
 		return targetService(endpoint, authEndpoint, authPublicKey)
 	})
-	resp, err := clientRequest(defaultHTTPClient, serverEndpoint)
+	resp, err := clientRequest(newClient(), serverEndpoint)
 	if err != nil {
 		log.Fatalf("client failed: %v", err)
 	}

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -23,8 +23,8 @@ import (
 	"net"
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 var defaultHTTPClient = httpbakery.NewHTTPClient()

--- a/bakery/example/meeting/meeting_test.go
+++ b/bakery/example/meeting/meeting_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
 )
 
 type suite struct{}

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -8,9 +8,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type targetServiceHandler struct {

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 type KeysSuite struct{}

--- a/bakery/mgostorage/storage.go
+++ b/bakery/mgostorage/storage.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 // New returns an implementation of Storage

--- a/bakery/mgostorage/storage_test.go
+++ b/bakery/mgostorage/storage_test.go
@@ -9,9 +9,9 @@ import (
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/mgo.v2"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
 )
 
 type StorageSuite struct {

--- a/bakery/service.go
+++ b/bakery/service.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 var logger = loggo.GetLogger("bakery")

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -7,8 +7,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type ServiceSuite struct{}

--- a/bakery/storage_test.go
+++ b/bakery/storage_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 type StorageSuite struct{}

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -30,7 +30,7 @@ type Discharger struct {
 // for any third party caveats returned by the checker.
 func NewDischarger(
 	locator bakery.PublicKeyLocator,
-	checker func(req *http.Request, cond, arg string) ([]checkers.Caveat, error),
+	checker func(req *http.Request, cond, arg string) ([]checkers.Caveat, *bakery.PublicKey, error),
 ) *Discharger {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -41,10 +41,10 @@ func NewDischarger(
 	if err != nil {
 		panic(err)
 	}
-	checker1 := func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+	checker1 := func(req *http.Request, cavId, cav string) ([]checkers.Caveat, *bakery.PublicKey, error) {
 		cond, arg, err := checkers.ParseCaveat(cav)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		return checker(req, cond, arg)
 	}

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 // Discharger is a third-party caveat discharger suitable

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -22,8 +22,8 @@ func (s *suite) SetUpTest(c *gc.C) {
 
 var _ = gc.Suite(&suite{})
 
-func noCaveatChecker(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
-	return nil, nil
+func noCaveatChecker(_ *http.Request, cond, arg string) ([]checkers.Caveat, *bakery.PublicKey, error) {
+	return nil, nil, nil
 }
 
 func (s *suite) TestDischargerSimple(c *gc.C) {
@@ -53,19 +53,19 @@ var failChecker = bakery.FirstPartyCheckerFunc(func(s string) error {
 })
 
 func (s *suite) TestDischargerTwoLevels(c *gc.C) {
-	d1checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
+	d1checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, *bakery.PublicKey, error) {
 		if cond != "xtrue" {
-			return nil, fmt.Errorf("caveat refused")
+			return nil, nil, fmt.Errorf("caveat refused")
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 	d1 := bakerytest.NewDischarger(nil, d1checker)
 	defer d1.Close()
-	d2checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
+	d2checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, *bakery.PublicKey, error) {
 		return []checkers.Caveat{{
 			Location:  d1.Location(),
 			Condition: "x" + cond,
-		}}, nil
+		}}, nil, nil
 	}
 	d2 := bakerytest.NewDischarger(d1, d2checker)
 	defer d2.Close()

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -6,10 +6,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/bakerytest"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakerytest"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type suite struct {

--- a/cmd/bakery-keygen/main.go
+++ b/cmd/bakery-keygen/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 func main() {

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type httpContext struct {

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -7,8 +7,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type CheckersSuite struct{}

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -98,16 +98,23 @@ func NewHTTPClient() *http.Client {
 // Client holds the context for making HTTP requests
 // that automatically acquire and discharge macaroons.
 type Client struct {
-	*http.Client
 	// Client holds the HTTP client to use. It should have
 	// a cookie jar configured, and when redirecting
 	// it should preserve the headers (see NewHTTPClient).
+	*http.Client
 
 	// VisitWebPage is called when the authorization process
 	// requires user interaction, and should cause the
 	// given URL to be opened in a web browser.
 	// If this is nil, no interaction will be allowed.
 	VisitWebPage func(*url.URL) error
+
+	// Key holds the client's key.
+	// If set, the client will be try to discharge third party
+	// caveats with the special location "self" by
+	// using this key. See bakery.DischargeAll for
+	// more information.
+	Key *bakery.KeyPair
 }
 
 // NewClient returns a new Client containing an HTTP client
@@ -118,7 +125,7 @@ func NewClient() *Client {
 	}
 }
 
-// Do makes an http request to the given client.
+// Do sends the given HTTP request and returns its response.
 // If the request fails with a discharge-required error,
 // any required discharge macaroons will be acquired,
 // and the request will be repeated with those attached.
@@ -127,13 +134,10 @@ func NewClient() *Client {
 // party, an error with a *DischargeError cause will be returned.
 //
 // Note that because the request may be retried, no
-// body may be provided in the http request (otherwise
-// the contents will be lost when retrying). For requests
+// body may be provided in the request, otherwise
+// the contents will be lost when retrying. For requests
 // with a body (for example PUT or POST methods),
 // use DoWithBody instead.
-//
-// If the client.Jar field is non-nil, the macaroons will be
-// stored there and made available to subsequent requests.
 //
 // If interaction is required by the user, the visitWebPage
 // function is called with a URL to be opened in a
@@ -148,10 +152,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return c.DoWithBody(req, nil)
 }
 
-func noBody() (io.ReadCloser, error) {
-	return nil, nil
-}
-
 // DischargeAll attempts to acquire discharge macaroons for all the
 // third party caveats in m, and returns a slice containing all
 // of them bound to m.
@@ -164,7 +164,7 @@ func noBody() (io.ReadCloser, error) {
 // The returned macaroon slice will not be stored in the client
 // cookie jar (see SetCookie if you need to do that).
 func (c *Client) DischargeAll(m *macaroon.Macaroon) (macaroon.Slice, error) {
-	return bakery.DischargeAll(m, c.obtainThirdPartyDischarge)
+	return bakery.DischargeAll(m, c.obtainThirdPartyDischarge, c.Key)
 }
 
 // PublicKeyForLocation returns the public key from a macaroon
@@ -254,7 +254,7 @@ func (c *Client) doWithBody(req *http.Request, body io.ReadSeeker) (*http.Respon
 		return nil, errgo.New("no macaroon found in response")
 	}
 	mac := resp.Info.Macaroon
-	macaroons, err := bakery.DischargeAll(mac, c.obtainThirdPartyDischarge)
+	macaroons, err := bakery.DischargeAll(mac, c.obtainThirdPartyDischarge, c.Key)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Any)
 	}

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -213,7 +213,7 @@ func relativeURL(base, new string) (*url.URL, error) {
 // DoWithBody is like Do except that the given body
 // is used for the body of the HTTP request,
 // and reset to its start by seeking if the request is
-// retried.
+// retried. It is an error if req.Body is non-zero.
 func (c *Client) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
 	logger.Debugf("client do %s %s {", req.Method, req.URL)
 	resp, err := c.doWithBody(req, body)
@@ -222,6 +222,9 @@ func (c *Client) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Respon
 }
 
 func (c *Client) doWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
+	if req.Body != nil {
+		return nil, errgo.New("body unexpectedly supplied in Request struct")
+	}
 	if c.Client.Jar == nil {
 		return nil, errgo.New("no cookie jar supplied in HTTP client")
 	}

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -16,8 +16,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 var logger = loggo.GetLogger("httpbakery")

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -15,10 +15,10 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v0/bakerytest"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakerytest"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type ClientSuite struct {

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -103,6 +103,15 @@ func (s *ClientSuite) TestRepeatedRequestWithBody(c *gc.C) {
 	c.Assert(bodyReader.byteCount, gc.Equals, len(bodyText)*2)
 }
 
+func (s *ClientSuite) TestDoWithBodyFailsWithBodyInRequest(c *gc.C) {
+	body := strings.NewReader("foo")
+	// Create a client request.
+	req, err := http.NewRequest("POST", "http://0.1.2.3/", body)
+	c.Assert(err, gc.IsNil)
+	_, err = httpbakery.NewClient().DoWithBody(req, body)
+	c.Assert(err, gc.ErrorMatches, "body unexpectedly supplied in Request struct")
+}
+
 func (s *ClientSuite) TestDischargeServerWithMacaraqOnDischarge(c *gc.C) {
 	locator := bakery.NewPublicKeyRing()
 

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -2,8 +2,6 @@ package httpbakery
 
 import (
 	"crypto/rand"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -17,7 +15,7 @@ import (
 
 type dischargeHandler struct {
 	svc     *bakery.Service
-	checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error)
+	checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, *bakery.PublicKey, error)
 }
 
 // AddDischargeHandler adds handlers to the given
@@ -52,26 +50,16 @@ type dischargeHandler struct {
 //			Macaroon *macaroon.Macaroon
 //		}
 //
-// POST /create
-//	params:
-//		condition: caveat condition to discharge
-//		rootkey: root key of discharge caveat
-//	result:
-//		{
-//			CaveatID: string
-//		}
-//
 // GET /publickey
 //	result:
 //		public key of service
 //		expiry time of key
-func AddDischargeHandler(mux *http.ServeMux, rootPath string, svc *bakery.Service, checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error)) {
+func AddDischargeHandler(mux *http.ServeMux, rootPath string, svc *bakery.Service, checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, *bakery.PublicKey, error)) {
 	d := &dischargeHandler{
 		svc:     svc,
 		checker: checker,
 	}
 	mux.Handle(path.Join(rootPath, "discharge"), handleJSON(d.serveDischarge))
-	mux.Handle(path.Join(rootPath, "create"), handleJSON(d.serveCreate))
 	// TODO(rog) is there a case for making public key caveat signing
 	// optional?
 	mux.Handle(path.Join(rootPath, "publickey"), handleJSON(d.servePublicKey))
@@ -103,7 +91,7 @@ func (d *dischargeHandler) serveDischarge1(h http.Header, req *http.Request) (in
 	if id == "" {
 		return nil, badRequestErrorf("id attribute is empty")
 	}
-	checker := func(cavId, cav string) ([]checkers.Caveat, error) {
+	checker := func(cavId, cav string) ([]checkers.Caveat, *bakery.PublicKey, error) {
 		return d.checker(req, cavId, cav)
 	}
 
@@ -117,53 +105,6 @@ func (d *dischargeHandler) serveDischarge1(h http.Header, req *http.Request) (in
 	}
 	resp.Macaroon = m
 	return &resp, nil
-}
-
-type thirdPartyCaveatIdRecord struct {
-	RootKey   []byte
-	Condition string
-}
-
-type caveatIdResponse struct {
-	CaveatId string
-	Error    string
-}
-
-func (d *dischargeHandler) serveCreate(h http.Header, req *http.Request) (interface{}, error) {
-	req.ParseForm()
-	condition := req.Form.Get("condition")
-	rootKeyStr := req.Form.Get("root-key")
-
-	if len(condition) == 0 {
-		return nil, badRequestErrorf("empty value for condition")
-	}
-	if len(rootKeyStr) == 0 {
-		return nil, badRequestErrorf("empty value for root key")
-	}
-	rootKey, err := base64.StdEncoding.DecodeString(rootKeyStr)
-	if err != nil {
-		return nil, badRequestErrorf("cannot base64-decode root key: %v", err)
-	}
-	// TODO(rog) what about expiry times?
-	idBytes, err := randomBytes(24)
-	if err != nil {
-		return nil, fmt.Errorf("cannot generate random key: %v", err)
-	}
-	id := fmt.Sprintf("%x", idBytes)
-	recordBytes, err := json.Marshal(thirdPartyCaveatIdRecord{
-		Condition: condition,
-		RootKey:   rootKey,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot marshal caveat id record: %v", err)
-	}
-	err = d.svc.Store().Put(id, string(recordBytes))
-	if err != nil {
-		return nil, fmt.Errorf("cannot store caveat id record: %v", err)
-	}
-	return caveatIdResponse{
-		CaveatId: id,
-	}, nil
 }
 
 type publicKeyResponse struct {

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/bakery"
-	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
 type dischargeHandler struct {

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -9,7 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 type ErrorSuite struct{}


### PR DESCRIPTION
This also includes a revamp of the httpbakery client interface
to make it based around a Client type, so it's easy to add
the Key field without requiring a new argument to be added
everywhere.

As a drive-by change, we also remove the redundant /create
endpoint in the discharger.
