### PR TITLE
httpbakery: introduce DischargeError

### DIFF
--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -100,7 +100,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	ms, err = httpbakery.DischargeAll(m, s.httpClient, noInteraction)
-	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "http://[^"]*": cannot discharge: caveat refused`)
+	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "http://[^"]*": third party refused discharge: cannot discharge: caveat refused`)
 	c.Assert(ms, gc.HasLen, 0)
 }
 

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"gopkg.in/macaroon-bakery.v0/httpbakery"
-	"gopkg.in/macaroon.v1"
 )
 
 type ErrorSuite struct{}


### PR DESCRIPTION
This will allow bakery clients to make decisions based on whether
some request was refused because of macaroon authorization.
