### PR TITLE
bakerytest: pass http.Request to discharger caveat checker

### DIFF
--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -30,7 +30,7 @@ type Discharger struct {
 // for any third party caveats returned by the checker.
 func NewDischarger(
 	locator bakery.PublicKeyLocator,
-	checker func(cond, arg string) ([]checkers.Caveat, error),
+	checker func(req *http.Request, cond, arg string) ([]checkers.Caveat, error),
 ) *Discharger {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -46,7 +46,7 @@ func NewDischarger(
 		if err != nil {
 			return nil, err
 		}
-		return checker(cond, arg)
+		return checker(req, cond, arg)
 	}
 	httpbakery.AddDischargeHandler(mux, "/", svc, checker1)
 	return &Discharger{

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -23,7 +23,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 
 var _ = gc.Suite(&suite{})
 
-func noCaveatChecker(cond, arg string) ([]checkers.Caveat, error) {
+func noCaveatChecker(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 	return nil, nil
 }
 
@@ -54,7 +54,7 @@ var failChecker = bakery.FirstPartyCheckerFunc(func(s string) error {
 })
 
 func (s *suite) TestDischargerTwoLevels(c *gc.C) {
-	d1checker := func(cond, arg string) ([]checkers.Caveat, error) {
+	d1checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 		if cond != "xtrue" {
 			return nil, fmt.Errorf("caveat refused")
 		}
@@ -62,7 +62,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	}
 	d1 := bakerytest.NewDischarger(nil, d1checker)
 	defer d1.Close()
-	d2checker := func(cond, arg string) ([]checkers.Caveat, error) {
+	d2checker := func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 		return []checkers.Caveat{{
 			Location:  d1.Location(),
 			Condition: "x" + cond,

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -253,7 +253,7 @@ func (s *ClientSuite) TestPublicKeyReturnsStatusInternalServerError(c *gc.C) {
 }
 
 func (s *ClientSuite) TestThirdPartyDischargeRefused(c *gc.C) {
-	d := bakerytest.NewDischarger(nil, func(cond, arg string) ([]checkers.Caveat, error) {
+	d := bakerytest.NewDischarger(nil, func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 		return nil, errgo.New("boo! cond " + cond)
 	})
 	defer d.Close()
@@ -278,7 +278,7 @@ func (s *ClientSuite) TestThirdPartyDischargeRefused(c *gc.C) {
 }
 
 func (s *ClientSuite) TestDischargeWithInteractionRequiredError(c *gc.C) {
-	d := bakerytest.NewDischarger(nil, func(cond, arg string) ([]checkers.Caveat, error) {
+	d := bakerytest.NewDischarger(nil, func(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 		return nil, &httpbakery.Error{
 			Code:    httpbakery.ErrInteractionRequired,
 			Message: "interaction required",
@@ -421,6 +421,6 @@ func (c isChecker) Check(_, arg string) error {
 	return nil
 }
 
-func noCaveatChecker(cond, arg string) ([]checkers.Caveat, error) {
+func noCaveatChecker(_ *http.Request, cond, arg string) ([]checkers.Caveat, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This allows us to write checkers that depend on the client request,
such as the cookies that are present.
