### PR TITLE
httpbakery: new Client type

### DIFF
--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -25,12 +25,13 @@ func clientRequest(httpClient *http.Client, serverEndpoint string) (string, erro
 	// when required, and retrying the request
 	// when necessary.
 
-	visitWebPage := func(url *url.URL) error {
+	client := httpbakery.NewClient()
+	client.VisitWebPage = func(url *url.URL) error {
 		fmt.Printf("please visit this web page:\n")
 		fmt.Printf("\t%s\n", url)
 		return nil
 	}
-	resp, err := httpbakery.Do(httpClient, req, visitWebPage)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", errgo.NoteMask(err, "GET failed", errgo.Any)
 	}

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -21,7 +21,7 @@ import (
 type suite struct {
 	authEndpoint  string
 	authPublicKey *bakery.PublicKey
-	httpClient    *http.Client
+	client        *httpbakery.Client
 }
 
 var _ = gc.Suite(&suite{})
@@ -55,7 +55,7 @@ func (s *suite) SetUpSuite(c *gc.C) {
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.httpClient = httpbakery.NewHTTPClient()
+	s.client = httpbakery.NewClient()
 }
 
 func (s *suite) TestIdService(c *gc.C) {
@@ -64,7 +64,7 @@ func (s *suite) TestIdService(c *gc.C) {
 	})
 	c.Logf("target service endpoint at %s", serverEndpoint)
 	visitDone := make(chan struct{})
-	visitWebPage := func(u *url.URL) error {
+	s.client.VisitWebPage = func(u *url.URL) error {
 		go func() {
 			err := s.scrapeLoginPage(u)
 			c.Logf("scrape returned %v", err)
@@ -73,7 +73,7 @@ func (s *suite) TestIdService(c *gc.C) {
 		}()
 		return nil
 	}
-	resp, err := s.clientRequest(serverEndpoint+"/gold", visitWebPage)
+	resp, err := s.clientRequest(serverEndpoint + "/gold")
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "all is golden")
 	select {
@@ -83,7 +83,8 @@ func (s *suite) TestIdService(c *gc.C) {
 	}
 
 	// Try again. We shouldn't need to interact this time.
-	resp, err = s.clientRequest(serverEndpoint+"/silver", noVisit)
+	s.client.VisitWebPage = nil
+	resp, err = s.clientRequest(serverEndpoint + "/silver")
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "every cloud has a silver lining")
 }
@@ -107,7 +108,7 @@ func serve(c *gc.C, newHandler func(string) (http.Handler, error)) (endpointURL 
 // client represents a client of the target service. In this simple
 // example, it just tries a GET request, which will fail unless the
 // client has the required authorization.
-func (s *suite) clientRequest(serverEndpoint string, visitWebPage func(*url.URL) error) (string, error) {
+func (s *suite) clientRequest(serverEndpoint string) (string, error) {
 	req, err := http.NewRequest("GET", serverEndpoint, nil)
 	if err != nil {
 		return "", errgo.Notef(err, "cannot make new HTTP request")
@@ -117,7 +118,7 @@ func (s *suite) clientRequest(serverEndpoint string, visitWebPage func(*url.URL)
 	// of actually gathering discharge macaroons
 	// when required, and retrying the request
 	// when necessary.
-	resp, err := httpbakery.Do(s.httpClient, req, visitWebPage)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return "", errgo.NoteMask(err, "GET failed", errgo.Any)
 	}
@@ -147,7 +148,7 @@ func (s *suite) scrapeLoginPage(loginURL *url.URL) error {
 	log.Printf("scraping login page")
 	// Get the page.
 	log.Printf("scrape: getting %s", loginURL)
-	resp, err := s.httpClient.Get(loginURL.String())
+	resp, err := s.client.Client.Get(loginURL.String())
 	if err != nil {
 		return errgo.Mask(err)
 	}
@@ -175,7 +176,7 @@ func (s *suite) scrapeLoginPage(loginURL *url.URL) error {
 	// Now simulate the user clicking on "Log in".
 	postURL := loginURL.ResolveReference(actionURL)
 	log.Printf("posting to %s (waitId %s)", postURL, waitId)
-	postResp, err := s.httpClient.PostForm(postURL.String(), url.Values{
+	postResp, err := s.client.Client.PostForm(postURL.String(), url.Values{
 		"user":     {"root"},
 		"password": {"superman"},
 		"waitid":   {waitId},

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -3,7 +3,6 @@ package bakerytest_test
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 
 	gc "gopkg.in/check.v1"
 
@@ -14,11 +13,11 @@ import (
 )
 
 type suite struct {
-	httpClient *http.Client
+	client *httpbakery.Client
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.httpClient = httpbakery.NewHTTPClient()
+	s.client = httpbakery.NewClient()
 }
 
 var _ = gc.Suite(&suite{})
@@ -41,7 +40,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 		Condition: "something",
 	}})
 	c.Assert(err, gc.IsNil)
-	ms, err := httpbakery.DischargeAll(m, s.httpClient, noInteraction)
+	ms, err := s.client.DischargeAll(m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 
@@ -86,7 +85,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	}})
 	c.Assert(err, gc.IsNil)
 
-	ms, err := httpbakery.DischargeAll(m, s.httpClient, noInteraction)
+	ms, err := s.client.DischargeAll(m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 3)
 
@@ -99,11 +98,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	ms, err = httpbakery.DischargeAll(m, s.httpClient, noInteraction)
+	ms, err = s.client.DischargeAll(m)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "http://[^"]*": third party refused discharge: cannot discharge: caveat refused`)
 	c.Assert(ms, gc.HasLen, 0)
-}
-
-func noInteraction(*url.URL) error {
-	return fmt.Errorf("unexpected interaction required")
 }

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -56,6 +56,13 @@ func IsInteractionError(err error) bool {
 	return ok
 }
 
+// WaitResponse holds the type that should be returned
+// by an HTTP response made to a WaitURL
+// (See the ErrorInfo type).
+type WaitResponse struct {
+	Macaroon *macaroon.Macaroon
+}
+
 // NewHTTPClient returns an http.Client that ensures
 // that headers are sent to the server even when the
 // server redirects a GET request. The returned client
@@ -88,11 +95,27 @@ func NewHTTPClient() *http.Client {
 	return &c
 }
 
-// WaitResponse holds the type that should be returned
-// by an HTTP response made to a WaitURL
-// (See the ErrorInfo type).
-type WaitResponse struct {
-	Macaroon *macaroon.Macaroon
+// Client holds the context for making HTTP requests
+// that automatically acquire and discharge macaroons.
+type Client struct {
+	*http.Client
+	// Client holds the HTTP client to use. It should have
+	// a cookie jar configured, and when redirecting
+	// it should preserve the headers (see NewHTTPClient).
+
+	// VisitWebPage is called when the authorization process
+	// requires user interaction, and should cause the
+	// given URL to be opened in a web browser.
+	// If this is nil, no interaction will be allowed.
+	VisitWebPage func(*url.URL) error
+}
+
+// NewClient returns a new Client containing an HTTP client
+// created with NewHTTPClient and leaves all other fields zero.
+func NewClient() *Client {
+	return &Client{
+		Client: NewHTTPClient(),
+	}
 }
 
 // Do makes an http request to the given client.
@@ -118,58 +141,30 @@ type WaitResponse struct {
 // an error with a *InteractionError cause will be returned.
 // See OpenWebBrowser for a possible implementation
 // of visitWebPage.
-func Do(client *http.Client, req *http.Request, visitWebPage func(url *url.URL) error) (*http.Response, error) {
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if req.Body != nil {
 		return nil, fmt.Errorf("body unexpectedly provided in request - use DoWithBody")
 	}
-	return DoWithBody(client, req, noBody, visitWebPage)
+	return c.DoWithBody(req, nil)
 }
 
 func noBody() (io.ReadCloser, error) {
 	return nil, nil
 }
 
-// DoWithBody is like Do except that the given getBody function is
-// called to obtain the body for the HTTP request. Any returned body
-// will be closed after each request is made.
-func DoWithBody(client *http.Client, req *http.Request, getBody BodyGetter, visitWebPage func(url *url.URL) error) (*http.Response, error) {
-	// Add a temporary cookie jar (without mutating the original
-	// client) if there isn't one available.
-	if client.Jar == nil {
-		client1 := *client
-		jar, err := cookiejar.New(&cookiejar.Options{
-			PublicSuffixList: publicsuffix.List,
-		})
-		if err != nil {
-			return nil, errgo.Notef(err, "cannot make cookie jar")
-		}
-		client1.Jar = jar
-		client = &client1
-	}
-	ctxt := &clientContext{
-		client:       client,
-		visitWebPage: visitWebPage,
-	}
-	return ctxt.do(req, getBody)
-}
-
 // DischargeAll attempts to acquire discharge macaroons for all the
-// third party caveats in m, and returns a slice containing all of them
-// bound to m.
+// third party caveats in m, and returns a slice containing all
+// of them bound to m.
 //
 // If the discharge fails because a third party refuses to discharge a
 // caveat, the returned error will have a cause of type *DischargeError.
 // If the discharge fails because visitWebPage returns an error,
 // the returned error will have a cause of *InteractionError.
 //
-// The returned macaroon slice will not be stored in the client cookie
-// jar (see SetCookie if you need to do that).
-func DischargeAll(m *macaroon.Macaroon, client *http.Client, visitWebPage func(url *url.URL) error) (macaroon.Slice, error) {
-	ctxt := &clientContext{
-		client:       client,
-		visitWebPage: visitWebPage,
-	}
-	return bakery.DischargeAll(m, ctxt.obtainThirdPartyDischarge)
+// The returned macaroon slice will not be stored in the client
+// cookie jar (see SetCookie if you need to do that).
+func (c *Client) DischargeAll(m *macaroon.Macaroon) (macaroon.Slice, error) {
+	return bakery.DischargeAll(m, c.obtainThirdPartyDischarge)
 }
 
 // PublicKeyForLocation returns the public key from a macaroon
@@ -199,11 +194,6 @@ func PublicKeyForLocation(client *http.Client, url string) (*bakery.PublicKey, e
 	return pubkey.PublicKey, nil
 }
 
-type clientContext struct {
-	client       *http.Client
-	visitWebPage func(*url.URL) error
-}
-
 // relativeURL returns newPath relative to an original URL.
 func relativeURL(base, new string) (*url.URL, error) {
 	if new == "" {
@@ -220,20 +210,27 @@ func relativeURL(base, new string) (*url.URL, error) {
 	return baseURL.ResolveReference(newURL), nil
 }
 
-func (ctxt *clientContext) do(req *http.Request, getBody BodyGetter) (*http.Response, error) {
+// DoWithBody is like Do except that the given body
+// is used for the body of the HTTP request,
+// and reset to its start by seeking if the request is
+// retried.
+func (c *Client) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
 	logger.Debugf("client do %s %s {", req.Method, req.URL)
-	resp, err := ctxt.do1(req, getBody)
+	resp, err := c.doWithBody(req, body)
 	logger.Debugf("} -> error %#v", err)
 	return resp, err
 }
 
-func (ctxt *clientContext) do1(req *http.Request, getBody BodyGetter) (*http.Response, error) {
-	if err := ctxt.setRequestBody(req, getBody); err != nil {
+func (c *Client) doWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
+	if c.Client.Jar == nil {
+		return nil, errgo.New("no cookie jar supplied in HTTP client")
+	}
+	if err := c.setRequestBody(req, body); err != nil {
 		return nil, errgo.Mask(err)
 	}
-	httpResp, err := ctxt.client.Do(req)
+	httpResp, err := c.Client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errgo.Mask(err, errgo.Any)
 	}
 	if httpResp.StatusCode != http.StatusProxyAuthRequired {
 		return httpResp, nil
@@ -254,7 +251,7 @@ func (ctxt *clientContext) do1(req *http.Request, getBody BodyGetter) (*http.Res
 		return nil, errgo.New("no macaroon found in response")
 	}
 	mac := resp.Info.Macaroon
-	macaroons, err := bakery.DischargeAll(mac, ctxt.obtainThirdPartyDischarge)
+	macaroons, err := bakery.DischargeAll(mac, c.obtainThirdPartyDischarge)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Any)
 	}
@@ -267,14 +264,14 @@ func (ctxt *clientContext) do1(req *http.Request, getBody BodyGetter) (*http.Res
 			cookieURL = req.URL.ResolveReference(relURL)
 		}
 	}
-	if err := SetCookie(ctxt.client.Jar, cookieURL, macaroons); err != nil {
+	if err := SetCookie(c.Jar, cookieURL, macaroons); err != nil {
 		return nil, errgo.Notef(err, "cannot set cookie")
 	}
-	if err := ctxt.setRequestBody(req, getBody); err != nil {
+	if err := c.setRequestBody(req, body); err != nil {
 		return nil, errgo.Mask(err)
 	}
 	// Try again with our newly acquired discharge macaroons
-	hresp, err := ctxt.client.Do(req)
+	hresp, err := c.Client.Do(req)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Any)
 	}
@@ -297,12 +294,18 @@ func parseURLPath(path string) (*url.URL, error) {
 	return u, nil
 }
 
-func (ctxt *clientContext) setRequestBody(req *http.Request, getBody BodyGetter) error {
-	body, err := getBody()
-	if err != nil {
-		return errgo.Notef(err, "cannot get request body")
+func (c *Client) setRequestBody(req *http.Request, body io.ReadSeeker) error {
+	if body == nil {
+		return nil
 	}
-	req.Body = body
+	if req.Body == nil {
+		req.Body = ioutil.NopCloser(body)
+	} else {
+		_, err := body.Seek(0, 0)
+		if err != nil {
+			return errgo.Notef(err, "cannot seek to start of request body")
+		}
+	}
 	return nil
 }
 
@@ -339,7 +342,7 @@ func SetCookie(jar http.CookieJar, url *url.URL, ms macaroon.Slice) error {
 	return nil
 }
 
-func (ctxt *clientContext) addCookie(req *http.Request, ms macaroon.Slice) error {
+func (c *Client) addCookie(req *http.Request, ms macaroon.Slice) error {
 	cookies, err := NewCookie(ms)
 	if err != nil {
 		return errgo.Mask(err)
@@ -347,7 +350,7 @@ func (ctxt *clientContext) addCookie(req *http.Request, ms macaroon.Slice) error
 	// TODO should we set it for the URL only, or the host.
 	// Can we set cookies such that they'll always get sent to any
 	// URL on the given host?
-	ctxt.client.Jar.SetCookies(req.URL, []*http.Cookie{cookies})
+	c.Jar.SetCookies(req.URL, []*http.Cookie{cookies})
 	return nil
 }
 
@@ -358,7 +361,7 @@ func appendURLElem(u, elem string) string {
 	return u + "/" + elem
 }
 
-func (ctxt *clientContext) obtainThirdPartyDischarge(originalLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+func (c *Client) obtainThirdPartyDischarge(originalLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 	var resp dischargeResponse
 	loc := appendURLElem(cav.Location, "discharge")
 	err := postFormJSON(
@@ -368,7 +371,7 @@ func (ctxt *clientContext) obtainThirdPartyDischarge(originalLocation string, ca
 			"location": {originalLocation},
 		},
 		&resp,
-		ctxt.postForm,
+		c.postForm,
 	)
 	if err == nil {
 		return resp.Macaroon, nil
@@ -385,7 +388,7 @@ func (ctxt *clientContext) obtainThirdPartyDischarge(originalLocation string, ca
 	if cause.Info == nil {
 		return nil, errgo.Notef(err, "interaction-required response with no info")
 	}
-	m, err := ctxt.interact(loc, cause.Info.VisitURL, cause.Info.WaitURL)
+	m, err := c.interact(loc, cause.Info.VisitURL, cause.Info.WaitURL)
 	if err != nil {
 		return nil, errgo.Mask(err, IsDischargeError, IsInteractionError)
 	}
@@ -394,7 +397,7 @@ func (ctxt *clientContext) obtainThirdPartyDischarge(originalLocation string, ca
 
 // interact gathers a macaroon by directing the user to interact
 // with a web page.
-func (ctxt *clientContext) interact(location, visitURLStr, waitURLStr string) (*macaroon.Macaroon, error) {
+func (c *Client) interact(location, visitURLStr, waitURLStr string) (*macaroon.Macaroon, error) {
 	visitURL, err := relativeURL(location, visitURLStr)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make relative visit URL")
@@ -403,12 +406,17 @@ func (ctxt *clientContext) interact(location, visitURLStr, waitURLStr string) (*
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make relative wait URL")
 	}
-	if err := ctxt.visitWebPage(visitURL); err != nil {
+	if c.VisitWebPage == nil {
+		return nil, &InteractionError{
+			Reason: errgo.New("interaction required but not possible"),
+		}
+	}
+	if err := c.VisitWebPage(visitURL); err != nil {
 		return nil, &InteractionError{
 			Reason: err,
 		}
 	}
-	waitResp, err := ctxt.client.Get(waitURL.String())
+	waitResp, err := c.Client.Get(waitURL.String())
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot get %q", waitURL)
 	}
@@ -432,34 +440,18 @@ func (ctxt *clientContext) interact(location, visitURLStr, waitURLStr string) (*
 	return resp.Macaroon, nil
 }
 
-func (ctxt *clientContext) postForm(url string, data url.Values) (*http.Response, error) {
-	getBody := SeekerBody(strings.NewReader(data.Encode()))
-	return ctxt.post(url, "application/x-www-form-urlencoded", getBody)
+func (c *Client) postForm(url string, data url.Values) (*http.Response, error) {
+	return c.post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
-// SeekerBody returns a body getter function suitable for
-// passing to DoWithBody that always returns the given reader,
-// first seeking to its start.
-func SeekerBody(r io.ReadSeeker) BodyGetter {
-	rc := ioutil.NopCloser(r)
-	return func() (io.ReadCloser, error) {
-		if _, err := r.Seek(0, 0); err != nil {
-			return nil, errgo.Notef(err, "cannot seek")
-		}
-		return rc, nil
-	}
-}
-
-type BodyGetter func() (io.ReadCloser, error)
-
-func (ctxt *clientContext) post(url string, bodyType string, getBody BodyGetter) (resp *http.Response, err error) {
+func (c *Client) post(url string, bodyType string, body io.ReadSeeker) (resp *http.Response, err error) {
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", bodyType)
 	// TODO(rog) see http.shouldRedirectPost
-	return ctxt.do(req, getBody)
+	return c.DoWithBody(req, body)
 }
 
 // postFormJSON does an HTTP POST request to the given url with the given


### PR DESCRIPTION
This means that both http.Client and httpbakery.Client implement
the same interface. It also makes it easier to add client-specific
information in the future.
