### PR TITLE
revert last commit (httpbakery: new Client type)

### DIFF
--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -25,13 +25,12 @@ func clientRequest(httpClient *http.Client, serverEndpoint string) (string, erro
 	// when required, and retrying the request
 	// when necessary.
 
-	client := httpbakery.NewClient()
-	client.VisitWebPage = func(url *url.URL) error {
+	visitWebPage := func(url *url.URL) error {
 		fmt.Printf("please visit this web page:\n")
 		fmt.Printf("\t%s\n", url)
 		return nil
 	}
-	resp, err := client.Do(req)
+	resp, err := httpbakery.Do(httpClient, req, visitWebPage)
 	if err != nil {
 		return "", errgo.NoteMask(err, "GET failed", errgo.Any)
 	}

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -21,7 +21,7 @@ import (
 type suite struct {
 	authEndpoint  string
 	authPublicKey *bakery.PublicKey
-	client        *httpbakery.Client
+	httpClient    *http.Client
 }
 
 var _ = gc.Suite(&suite{})
@@ -55,7 +55,7 @@ func (s *suite) SetUpSuite(c *gc.C) {
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.client = httpbakery.NewClient()
+	s.httpClient = httpbakery.NewHTTPClient()
 }
 
 func (s *suite) TestIdService(c *gc.C) {
@@ -64,7 +64,7 @@ func (s *suite) TestIdService(c *gc.C) {
 	})
 	c.Logf("target service endpoint at %s", serverEndpoint)
 	visitDone := make(chan struct{})
-	s.client.VisitWebPage = func(u *url.URL) error {
+	visitWebPage := func(u *url.URL) error {
 		go func() {
 			err := s.scrapeLoginPage(u)
 			c.Logf("scrape returned %v", err)
@@ -73,7 +73,7 @@ func (s *suite) TestIdService(c *gc.C) {
 		}()
 		return nil
 	}
-	resp, err := s.clientRequest(serverEndpoint + "/gold")
+	resp, err := s.clientRequest(serverEndpoint+"/gold", visitWebPage)
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "all is golden")
 	select {
@@ -83,8 +83,7 @@ func (s *suite) TestIdService(c *gc.C) {
 	}
 
 	// Try again. We shouldn't need to interact this time.
-	s.client.VisitWebPage = nil
-	resp, err = s.clientRequest(serverEndpoint + "/silver")
+	resp, err = s.clientRequest(serverEndpoint+"/silver", noVisit)
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp, gc.Equals, "every cloud has a silver lining")
 }
@@ -108,7 +107,7 @@ func serve(c *gc.C, newHandler func(string) (http.Handler, error)) (endpointURL 
 // client represents a client of the target service. In this simple
 // example, it just tries a GET request, which will fail unless the
 // client has the required authorization.
-func (s *suite) clientRequest(serverEndpoint string) (string, error) {
+func (s *suite) clientRequest(serverEndpoint string, visitWebPage func(*url.URL) error) (string, error) {
 	req, err := http.NewRequest("GET", serverEndpoint, nil)
 	if err != nil {
 		return "", errgo.Notef(err, "cannot make new HTTP request")
@@ -118,7 +117,7 @@ func (s *suite) clientRequest(serverEndpoint string) (string, error) {
 	// of actually gathering discharge macaroons
 	// when required, and retrying the request
 	// when necessary.
-	resp, err := s.client.Do(req)
+	resp, err := httpbakery.Do(s.httpClient, req, visitWebPage)
 	if err != nil {
 		return "", errgo.NoteMask(err, "GET failed", errgo.Any)
 	}
@@ -148,7 +147,7 @@ func (s *suite) scrapeLoginPage(loginURL *url.URL) error {
 	log.Printf("scraping login page")
 	// Get the page.
 	log.Printf("scrape: getting %s", loginURL)
-	resp, err := s.client.Client.Get(loginURL.String())
+	resp, err := s.httpClient.Get(loginURL.String())
 	if err != nil {
 		return errgo.Mask(err)
 	}
@@ -176,7 +175,7 @@ func (s *suite) scrapeLoginPage(loginURL *url.URL) error {
 	// Now simulate the user clicking on "Log in".
 	postURL := loginURL.ResolveReference(actionURL)
 	log.Printf("posting to %s (waitId %s)", postURL, waitId)
-	postResp, err := s.client.Client.PostForm(postURL.String(), url.Values{
+	postResp, err := s.httpClient.PostForm(postURL.String(), url.Values{
 		"user":     {"root"},
 		"password": {"superman"},
 		"waitid":   {waitId},

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -3,6 +3,7 @@ package bakerytest_test
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	gc "gopkg.in/check.v1"
 
@@ -13,11 +14,11 @@ import (
 )
 
 type suite struct {
-	client *httpbakery.Client
+	httpClient *http.Client
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.client = httpbakery.NewClient()
+	s.httpClient = httpbakery.NewHTTPClient()
 }
 
 var _ = gc.Suite(&suite{})
@@ -40,7 +41,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 		Condition: "something",
 	}})
 	c.Assert(err, gc.IsNil)
-	ms, err := s.client.DischargeAll(m)
+	ms, err := httpbakery.DischargeAll(m, s.httpClient, noInteraction)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 
@@ -85,7 +86,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	}})
 	c.Assert(err, gc.IsNil)
 
-	ms, err := s.client.DischargeAll(m)
+	ms, err := httpbakery.DischargeAll(m, s.httpClient, noInteraction)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 3)
 
@@ -98,7 +99,11 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	ms, err = s.client.DischargeAll(m)
+	ms, err = httpbakery.DischargeAll(m, s.httpClient, noInteraction)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "http://[^"]*": third party refused discharge: cannot discharge: caveat refused`)
 	c.Assert(ms, gc.HasLen, 0)
+}
+
+func noInteraction(*url.URL) error {
+	return fmt.Errorf("unexpected interaction required")
 }

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -81,7 +81,7 @@ func (s *ClientSuite) TestRepeatedRequestWithBody(c *gc.C) {
 	// First try with a body in the request, which should be denied
 	// because we must use DoWithBody.
 	req.Body = ioutil.NopCloser(strings.NewReader("postbody"))
-	resp, err := httpbakery.NewClient().Do(req)
+	resp, err := httpbakery.Do(httpbakery.NewHTTPClient(), req, noVisit)
 	c.Assert(err, gc.ErrorMatches, "body unexpectedly provided in request - use DoWithBody")
 	c.Assert(resp, gc.IsNil)
 
@@ -93,7 +93,7 @@ func (s *ClientSuite) TestRepeatedRequestWithBody(c *gc.C) {
 	bodyText := "postbody"
 	bodyReader := &readCounter{ReadSeeker: strings.NewReader(bodyText)}
 
-	resp, err = httpbakery.NewClient().DoWithBody(req, bodyReader)
+	resp, err = httpbakery.DoWithBody(httpbakery.NewHTTPClient(), req, httpbakery.SeekerBody(bodyReader), noVisit)
 	c.Assert(err, gc.IsNil)
 	defer resp.Body.Close()
 	assertResponse(c, resp, "done postbody")
@@ -138,10 +138,10 @@ func (s *ClientSuite) TestDischargeServerWithMacaraqOnDischarge(c *gc.C) {
 	srv0 := httptest.NewServer(serverHandler(svc0, srv1.URL, nil))
 
 	// Make a client request.
-	client := httpbakery.NewClient()
+	client := httpbakery.NewHTTPClient()
 	req, err := http.NewRequest("GET", srv0.URL, nil)
 	c.Assert(err, gc.IsNil)
-	resp, err := client.Do(req)
+	resp, err := httpbakery.Do(client, req, noVisit)
 	c.Assert(err, gc.IsNil)
 	defer resp.Body.Close()
 	assertResponse(c, resp, "done")
@@ -167,12 +167,12 @@ func (s *ClientSuite) TestMacaroonCookiePath(c *gc.C) {
 	}))
 	defer ts.Close()
 
-	var client *httpbakery.Client
+	var client *http.Client
 	doRequest := func() {
 		req, err := http.NewRequest("GET", ts.URL+"/foo/bar/", nil)
 		c.Assert(err, gc.IsNil)
-		client = httpbakery.NewClient()
-		resp, err := client.Do(req)
+		client = httpbakery.NewHTTPClient()
+		resp, err := httpbakery.Do(client, req, noVisit)
 		c.Assert(err, gc.IsNil)
 		defer resp.Body.Close()
 		assertResponse(c, resp, "done")
@@ -268,10 +268,10 @@ func (s *ClientSuite) TestThirdPartyDischargeRefused(c *gc.C) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	c.Assert(err, gc.IsNil)
 
-	client := httpbakery.NewClient()
+	client := httpbakery.NewHTTPClient()
 
 	// Make the request to the server.
-	resp, err := client.Do(req)
+	resp, err := httpbakery.Do(client, req, noVisit)
 	c.Assert(errgo.Cause(err), gc.FitsTypeOf, (*httpbakery.DischargeError)(nil))
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from ".*": third party refused discharge: cannot discharge: boo! cond is-ok`)
 	c.Assert(resp, gc.IsNil)
@@ -300,14 +300,13 @@ func (s *ClientSuite) TestDischargeWithInteractionRequiredError(c *gc.C) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	c.Assert(err, gc.IsNil)
 
-	errCannotVisit := errgo.New("cannot visit")
-	client := httpbakery.NewClient()
-	client.VisitWebPage = func(*url.URL) error {
-		return errCannotVisit
-	}
+	client := httpbakery.NewHTTPClient()
 
+	errCannotVisit := errgo.New("cannot visit")
 	// Make the request to the server.
-	resp, err := client.Do(req)
+	resp, err := httpbakery.Do(client, req, func(*url.URL) error {
+		return errCannotVisit
+	})
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from ".*": cannot start interactive session: cannot visit`)
 	c.Assert(httpbakery.IsInteractionError(errgo.Cause(err)), gc.Equals, true)
 	ierr, ok := errgo.Cause(err).(*httpbakery.InteractionError)


### PR DESCRIPTION
The client API change caused all kinds of problems with
clients of the bakery. Instead of breaking the API,
we keep it the same but create a new (stable) version
of the bakery at gopkg.in/macaroon-bakery.v1
that incorporates the changes that are reverted here.
