### PR TITLE
httpbakery: do not allow req.Body to be set in DoWithBody

### DIFF
--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -213,7 +213,7 @@ func relativeURL(base, new string) (*url.URL, error) {
 // DoWithBody is like Do except that the given body
 // is used for the body of the HTTP request,
 // and reset to its start by seeking if the request is
-// retried.
+// retried. It is an error if req.Body is non-zero.
 func (c *Client) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
 	logger.Debugf("client do %s %s {", req.Method, req.URL)
 	resp, err := c.doWithBody(req, body)
@@ -222,6 +222,9 @@ func (c *Client) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Respon
 }
 
 func (c *Client) doWithBody(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
+	if req.Body != nil {
+		return nil, errgo.New("body unexpectedly supplied in Request struct")
+	}
 	if c.Client.Jar == nil {
 		return nil, errgo.New("no cookie jar supplied in HTTP client")
 	}

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -103,6 +103,15 @@ func (s *ClientSuite) TestRepeatedRequestWithBody(c *gc.C) {
 	c.Assert(bodyReader.byteCount, gc.Equals, len(bodyText)*2)
 }
 
+func (s *ClientSuite) TestDoWithBodyFailsWithBodyInRequest(c *gc.C) {
+	body := strings.NewReader("foo")
+	// Create a client request.
+	req, err := http.NewRequest("POST", "http://0.1.2.3/", body)
+	c.Assert(err, gc.IsNil)
+	_, err = httpbakery.NewClient().DoWithBody(req, body)
+	c.Assert(err, gc.ErrorMatches, "body unexpectedly supplied in Request struct")
+}
+
 func (s *ClientSuite) TestDischargeServerWithMacaraqOnDischarge(c *gc.C) {
 	locator := bakery.NewPublicKeyRing()
 


### PR DESCRIPTION
I got a very confusing test failure when we were accidentally doing this.
