### PR TITLE
bakery: add support for self-discharged 3rd party caveats

### DIFF
--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -5,17 +5,35 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v1"
+
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 )
 
-// DischargeAll gathers discharge macaroons for all the third party caveats
-// in m (and any subsequent caveats required by those) using getDischarge to
-// acquire each discharge macaroon.
-// It returns a slice with m as the first element, followed by
-// all the discharge macaroons. All the discharge macaroons
-// will be bound to the primary macaroon.
+// DischargeAll gathers discharge macaroons for all the third party
+// caveats in m (and any subsequent caveats required by those) using
+// getDischarge to acquire each discharge macaroon. It returns a slice
+// with m as the first element, followed by all the discharge macaroons.
+// All the discharge macaroons will be bound to the primary macaroon.
 func DischargeAll(
 	m *macaroon.Macaroon,
 	getDischarge func(firstPartyLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error),
+) (macaroon.Slice, error) {
+	return DischargeAllWithKey(m, getDischarge, nil)
+}
+
+// DischargeAllWithKey is like DischargeAll except that the localKey
+// parameter may optionally hold the key of the client, in which case it
+// will be used to discharge any third party caveats with the special
+// location "local". In this case, the caveat itself must be "true". This
+// can be used be a server to ask a client to prove ownership of the
+// private key.
+//
+// When localKey is nil, DischargeAllWithKey is exactly the same as
+// DischargeAll.
+func DischargeAllWithKey(
+	m *macaroon.Macaroon,
+	getDischarge func(firstPartyLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error),
+	localKey *KeyPair,
 ) (macaroon.Slice, error) {
 	sig := m.Signature()
 	discharges := macaroon.Slice{m}
@@ -33,7 +51,13 @@ func DischargeAll(
 	for len(need) > 0 {
 		cav := need[0]
 		need = need[1:]
-		dm, err := getDischarge(firstPartyLocation, cav)
+		var dm *macaroon.Macaroon
+		var err error
+		if localKey != nil && cav.Location == "local" {
+			dm, _, err = Discharge(localKey, localDischargeChecker, cav.Id)
+		} else {
+			dm, err = getDischarge(firstPartyLocation, cav)
+		}
 		if err != nil {
 			return nil, errgo.NoteMask(err, fmt.Sprintf("cannot get discharge from %q", cav.Location), errgo.Any)
 		}
@@ -43,3 +67,10 @@ func DischargeAll(
 	}
 	return discharges, nil
 }
+
+var localDischargeChecker = ThirdPartyCheckerFunc(func(caveatId, caveat string) ([]checkers.Caveat, error) {
+	if caveat != "true" {
+		return nil, checkers.ErrCaveatNotRecognized
+	}
+	return nil, nil
+})

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"gopkg.in/errgo.v1"
 
@@ -15,21 +14,14 @@ import (
 // In this simple example, it just tries a GET
 // request, which will fail unless the client
 // has the required authorization.
-func clientRequest(httpClient *http.Client, serverEndpoint string) (string, error) {
-	req, err := http.NewRequest("GET", serverEndpoint, nil)
-	if err != nil {
-		return "", errgo.Notef(err, "cannot make new HTTP request")
-	}
+func clientRequest(client *httpbakery.Client, serverEndpoint string) (string, error) {
 	// The Do function implements the mechanics
 	// of actually gathering discharge macaroons
 	// when required, and retrying the request
 	// when necessary.
-
-	client := httpbakery.NewClient()
-	client.VisitWebPage = func(url *url.URL) error {
-		fmt.Printf("please visit this web page:\n")
-		fmt.Printf("\t%s\n", url)
-		return nil
+	req, err := http.NewRequest("GET", serverEndpoint, nil)
+	if err != nil {
+		return "", errgo.Notef(err, "cannot make new HTTP request")
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -89,10 +89,6 @@ func (s *suite) TestIdService(c *gc.C) {
 	c.Assert(resp, gc.Equals, "every cloud has a silver lining")
 }
 
-func noVisit(*url.URL) error {
-	return errgo.New("should not be visiting")
-}
-
 func serve(c *gc.C, newHandler func(string) (http.Handler, error)) (endpointURL string) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, gc.IsNil)

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -41,7 +41,7 @@ func main() {
 	serverEndpoint := mustServe(func(endpoint string) (http.Handler, error) {
 		return targetService(endpoint, authEndpoint, authPublicKey)
 	})
-	resp, err := clientRequest(defaultHTTPClient, serverEndpoint)
+	resp, err := clientRequest(newClient(), serverEndpoint)
 	if err != nil {
 		log.Fatalf("client failed: %v", err)
 	}

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -75,6 +75,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		return mac, nil
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	err = ts.Check(d, strcmpChecker(""))
@@ -134,6 +135,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithBindingOnTamperedSignature(
 		c.Assert(err, gc.IsNil)
 		return mac, nil
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// client has all the discharge macaroons. For each discharge macaroon bind it to our tsMacaroon
@@ -166,6 +168,7 @@ func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 	d, err := bakery.DischargeAll(m, func(_ string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 		return thirdParty.Discharge(strcmpChecker("something"), cav.Id)
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// The required declared attributes should have been added
@@ -191,6 +194,7 @@ func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 		}
 		return thirdParty.Discharge(checker, cav.Id)
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// One attribute should have been added, the other was already there.
@@ -214,10 +218,10 @@ func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 		m, err := thirdParty.Discharge(checker, cav.Id)
 		c.Assert(err, gc.IsNil)
 
-		// Sneaky client adds a first party caveat.
 		m.AddFirstPartyCaveat(checkers.DeclaredCaveat("foo", "c").Condition)
 		return m, nil
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	declared = checkers.InferDeclared(d)
@@ -256,6 +260,7 @@ func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
 			return nil, nil
 		}), cav.Id)
 	})
+
 	c.Assert(err, gc.IsNil)
 	declared := checkers.InferDeclared(d)
 	c.Assert(declared, gc.DeepEquals, checkers.Declared{
@@ -282,9 +287,10 @@ func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
 					checkers.DeclaredCaveat("baz", "bazval"),
 				}, nil
 			}
-			return nil, fmt.Errorf("no matched")
+			return nil, fmt.Errorf("not matched")
 		}), cav.Id)
 	})
+
 	c.Assert(err, gc.IsNil)
 	declared = checkers.InferDeclared(d)
 	c.Assert(declared, gc.DeepEquals, checkers.Declared{


### PR DESCRIPTION
This will support agent non-interactive authorization. The changes are intended to be backwardly compatible - please sing out if any API-breaking changes are seen.
