### PR TITLE
httpbakery: add some more client tests

### DIFF
--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -428,9 +428,10 @@ func (c *Client) interact(location, visitURLStr, waitURLStr string) (*macaroon.M
 		if err := json.NewDecoder(waitResp.Body).Decode(&resp); err != nil {
 			return nil, errgo.Notef(err, "cannot unmarshal wait error response")
 		}
-		return nil, errgo.WithCausef(nil, &DischargeError{
+		dischargeErr := &DischargeError{
 			Reason: &resp,
-		}, "failed to acquire macaroon after waiting")
+		}
+		return nil, errgo.NoteMask(dischargeErr, "failed to acquire macaroon after waiting", errgo.Any)
 	}
 	var resp WaitResponse
 	if err := json.NewDecoder(waitResp.Body).Decode(&resp); err != nil {


### PR DESCRIPTION
The error message produced on a wait failure was uninformative.
This fixes that and adds some more tests. More can be added
to the table later, but this substantially increases test coverage as is.
