### PR TITLE
httpbakery: add NewInteractionRequiredError function

### DIFF
--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -1,10 +1,13 @@
 package httpbakery_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/juju/httprequest"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
@@ -68,4 +71,52 @@ func (s *ErrorSuite) TestWriteDischargeRequiredError(c *gc.C) {
 		httpbakery.WriteDischargeRequiredError(response, m, t.path, t.err)
 		httptesting.AssertJSONResponse(c, response, http.StatusProxyAuthRequired, t.expectedResponse)
 	}
+}
+
+func (s *ErrorSuite) TestNewInteractionRequiredError(c *gc.C) {
+	// With a request with no version header, the response
+	// should be 407.
+	req, err := http.NewRequest("GET", "/", nil)
+	c.Assert(err, gc.IsNil)
+
+	err = httpbakery.NewInteractionRequiredError("/visit", "/wait", nil, req)
+	code, resp := httpbakery.ErrorToResponse(err)
+	c.Assert(code, gc.Equals, http.StatusProxyAuthRequired)
+
+	data, err := json.Marshal(resp)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(string(data), jc.JSONEquals, &httpbakery.Error{
+		Code:    httpbakery.ErrInteractionRequired,
+		Message: httpbakery.ErrInteractionRequired.Error(),
+		Info: &httpbakery.ErrorInfo{
+			VisitURL: "/visit",
+			WaitURL:  "/wait",
+		},
+	})
+
+	// With a request with a version 1 header, the response
+	// should be 401.
+	req.Header.Set("Bakery-Protocol-Version", "1")
+
+	err = httpbakery.NewInteractionRequiredError("/visit", "/wait", nil, req)
+	code, resp = httpbakery.ErrorToResponse(err)
+	c.Assert(code, gc.Equals, http.StatusUnauthorized)
+
+	h := make(http.Header)
+	resp.(httprequest.HeaderSetter).SetHeader(h)
+	c.Assert(h.Get("WWW-Authenticate"), gc.Equals, "Macaroon")
+
+	data, err = json.Marshal(resp)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(string(data), jc.JSONEquals, &httpbakery.Error{
+		Code:    httpbakery.ErrInteractionRequired,
+		Message: httpbakery.ErrInteractionRequired.Error(),
+		Info: &httpbakery.ErrorInfo{
+			VisitURL: "/visit",
+			WaitURL:  "/wait",
+		},
+	})
+
 }


### PR DESCRIPTION
The discharge-required error isn't the only one that needs special treatment.
This allows the interaction-required error to return a 401 response too,
while preserving backward compatibility.
