### PR TITLE
bakery: return an error if CheckAny is called with no macaroons

### DIFF
--- a/bakery/service.go
+++ b/bakery/service.go
@@ -144,6 +144,11 @@ func (svc *Service) Check(ms macaroon.Slice, checker FirstPartyChecker) error {
 //
 // It returns any attributes declared in the successfully validated request.
 func (svc *Service) CheckAny(mss []macaroon.Slice, assert map[string]string, checker checkers.Checker) (map[string]string, error) {
+	if len(mss) == 0 {
+		return nil, &VerificationError{
+			Reason: errgo.Newf("no macaroons"),
+		}
+	}
 	// TODO perhaps return a slice of attribute maps, one
 	// for each successfully validated macaroon slice?
 	var err error


### PR DESCRIPTION
CheckAny would erroneously succeed when provided with no macaroons.
In most situations this wasn't a problem in practice because most clients
use httpbakery.CheckRequest which does its own check for this condition,
but it's still a potential ravening security hole.

Also add a set of tests for CheckAny because there were none before.
