### PR TITLE
Allow customizing discharge acquisition.

### DIFF
--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -114,6 +114,19 @@ type Client struct {
 	// "local" by using this key. See bakery.DischargeAllWithKey and
 	// bakery.LocalThirdPartyCaveat for more information
 	Key *bakery.KeyPair
+
+	// DischargeAcquirer holds the object that will be used to obtain
+	// third-party discharges. If nil, the Client itself will be used.
+	DischargeAcquirer DischargeAcquirer
+}
+
+// DischargeAcquirer can be implemented by clients that want to customize the
+// discharge-acquisition process used by a Client.
+type DischargeAcquirer interface {
+	// AcquireDischarge should return a discharge macaroon for the given third
+	// party caveat. The firstPartyLocation holds the location of the original
+	// macaroon.
+	AcquireDischarge(firstPartyLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error)
 }
 
 // NewClient returns a new Client containing an HTTP client
@@ -161,7 +174,14 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // The returned macaroon slice will not be stored in the client
 // cookie jar (see SetCookie if you need to do that).
 func (c *Client) DischargeAll(m *macaroon.Macaroon) (macaroon.Slice, error) {
-	return bakery.DischargeAllWithKey(m, c.obtainThirdPartyDischarge, c.Key)
+	return bakery.DischargeAllWithKey(m, c.dischargeAcquirer().AcquireDischarge, c.Key)
+}
+
+func (c *Client) dischargeAcquirer() DischargeAcquirer {
+	if c.DischargeAcquirer != nil {
+		return c.DischargeAcquirer
+	}
+	return c
 }
 
 // PublicKeyForLocation returns the public key from a macaroon
@@ -266,7 +286,7 @@ func (c *Client) doWithBody(req *http.Request, body io.ReadSeeker, getError func
 		return nil, errgo.New("no macaroon found in discharge-required response")
 	}
 	mac := respErr.Info.Macaroon
-	macaroons, err := bakery.DischargeAllWithKey(mac, c.obtainThirdPartyDischarge, c.Key)
+	macaroons, err := bakery.DischargeAllWithKey(mac, c.dischargeAcquirer().AcquireDischarge, c.Key)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Any)
 	}
@@ -406,7 +426,9 @@ func appendURLElem(u, elem string) string {
 	return u + "/" + elem
 }
 
-func (c *Client) obtainThirdPartyDischarge(originalLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+// AcquireDischarge implements DischargeAcquirer by requesting a discharge
+// macaroon from the caveat location as an HTTP URL.
+func (c *Client) AcquireDischarge(originalLocation string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 	var resp dischargeResponse
 	loc := appendURLElem(cav.Location, "discharge")
 	err := postFormJSON(

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -235,6 +235,60 @@ func newHTTPDischarger(locator bakery.PublicKeyLocator, checker func(svc *bakery
 	return svc.PublicKey(), mux
 }
 
+func (s *ClientSuite) TestDischargeAcquirer(c *gc.C) {
+	rootKey := []byte("secret")
+	m, err := macaroon.New(rootKey, "", "here")
+	c.Assert(err, gc.IsNil)
+
+	dischargeRootKey := []byte("shared root key")
+	thirdPartyCaveatId := "3rd party caveat"
+	err = m.AddThirdPartyCaveat(dischargeRootKey, thirdPartyCaveatId, "there")
+	c.Assert(err, gc.IsNil)
+
+	dm, err := macaroon.New(dischargeRootKey, thirdPartyCaveatId, "there")
+	c.Assert(err, gc.IsNil)
+
+	ta := &testAcquirer{dischargeMacaroon: dm}
+	cl := httpbakery.NewClient()
+	cl.DischargeAcquirer = ta
+
+	ms, err := cl.DischargeAll(m)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	c.Assert(ta.acquireLocation, gc.Equals, "here") // should be first-party location
+	c.Assert(ta.acquireCaveat.Id, gc.Equals, thirdPartyCaveatId)
+	expectCaveat := "must foo"
+	var lastCaveat string
+	err = ms[0].Verify(rootKey, func(s string) error {
+		if s != expectCaveat {
+			return errgo.Newf(`expected %q, got %q`, expectCaveat, s)
+		}
+		lastCaveat = s
+		return nil
+	}, ms[1:])
+	c.Assert(err, gc.IsNil)
+	c.Assert(lastCaveat, gc.Equals, expectCaveat)
+}
+
+type testAcquirer struct {
+	dischargeMacaroon *macaroon.Macaroon
+
+	acquireLocation string
+	acquireCaveat   macaroon.Caveat
+}
+
+// AcquireDischarge implements httpbakery.DischargeAcquirer.
+func (ta *testAcquirer) AcquireDischarge(loc string, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+	ta.acquireLocation = loc
+	ta.acquireCaveat = cav
+	err := ta.dischargeMacaroon.AddFirstPartyCaveat("must foo")
+	if err != nil {
+		return nil, err
+	}
+	return ta.dischargeMacaroon, nil
+}
+
 func (s *ClientSuite) TestMacaroonCookiePath(c *gc.C) {
 	svc := newService("loc", nil)
 


### PR DESCRIPTION
Added a DischargeAcquirer field to httpbakery.Client, which is an interface that is used to obtain third-party discharge macaroons. If not set, it falls back to the HTTP implementation provided by the Client itself.
