### PR TITLE
httpbakery: return generic error from getError

### DIFF
--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -687,7 +687,7 @@ func (s *ClientSuite) TestDoWithBodyAndCustomError(c *gc.C) {
 	callCount = 0
 
 	// Then check that a request with a custom error getter succeeds.
-	errorGetter := func(resp *http.Response) *httpbakery.Error {
+	errorGetter := func(resp *http.Response) error {
 		if resp.StatusCode != http.StatusTeapot {
 			return nil
 		}


### PR DESCRIPTION
The new DoWithBodyAndCustomError turned out to be awkward to
use in practice. This makes things a bit easier to use - it's possible
to return any kind of error from the getError function and we explicitly
document that the discharge-required error is the only kind of error
that we really care about.

Note that technically this is a backwardly incompatible change, but
the API has only existed for a few days so there are very unlikely
to be clients already reliant on it.
