### PR TITLE
httpbakery: allow servers to set desired cookie name

### DIFF
--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -313,6 +313,9 @@ func (c *Client) HandleError(reqURL *url.URL, err error) error {
 		return errgo.Notef(err, "cannot make cookie")
 	}
 	cookie.Path = cookiePath
+	if name := respErr.Info.CookieNameSuffix; name != "" {
+		cookie.Name = "macaroon-" + name
+	}
 	c.Jar.SetCookies(reqURL, []*http.Cookie{cookie})
 	return nil
 }
@@ -439,18 +442,6 @@ func SetCookie(jar http.CookieJar, url *url.URL, ms macaroon.Slice) error {
 // given URL in the given cookie jar.
 func MacaroonsForURL(jar http.CookieJar, u *url.URL) []macaroon.Slice {
 	return cookiesToMacaroons(jar.Cookies(u))
-}
-
-func (c *Client) addCookie(req *http.Request, ms macaroon.Slice) error {
-	cookies, err := NewCookie(ms)
-	if err != nil {
-		return errgo.Mask(err)
-	}
-	// TODO should we set it for the URL only, or the host.
-	// Can we set cookies such that they'll always get sent to any
-	// URL on the given host?
-	c.Jar.SetCookies(req.URL, []*http.Cookie{cookies})
-	return nil
 }
 
 func appendURLElem(u, elem string) string {

--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -77,6 +77,13 @@ type ErrorInfo struct {
 	// the original URL from which the error was returned.
 	MacaroonPath string `json:",omitempty"`
 
+	// CookieNameSuffix holds the desired cookie name suffix to be
+	// associated with the macaroon. The actual name used will be
+	// ("macaroon-" + CookieName). Clients may ignore this field -
+	// older clients will always use ("macaroon-" +
+	// macaroon.Signature() in hex).
+	CookieNameSuffix string `json:",omitempty"`
+
 	// VisitURL and WaitURL are associated with the
 	// ErrInteractionRequired error code.
 
@@ -235,6 +242,11 @@ func NewInteractionRequiredError(visitURL, waitURL string, originalErr error, re
 // This function should always be used in preference to
 // NewDischargeRequiredError, because it enables in-browser macaroon
 // discharge.
+//
+// To request a particular cookie name:
+//
+//	err := NewDischargeRequiredErrorForRequest(...)
+//	err.(*httpbakery.Error).Info.CookieNameSuffix = cookieName
 func NewDischargeRequiredErrorForRequest(m *macaroon.Macaroon, path string, originalErr error, req *http.Request) error {
 	v := versionFromRequest(req)
 	return newDischargeRequiredErrorWithVersion(m, path, originalErr, v)


### PR DESCRIPTION
This will allow us to mitigate cookie buildup in clients.
