### PR TITLE
httpbakery: add origin checker

### DIFF
--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -17,6 +17,7 @@ const (
 	CondDeclared     = "declared"
 	CondTimeBefore   = "time-before"
 	CondClientIPAddr = "client-ip-addr"
+	CondClientOrigin = "origin"
 	CondError        = "error"
 	CondNeedDeclared = "need-declared"
 	CondAllow        = "allow"
@@ -221,6 +222,12 @@ func ClientIPAddrCaveat(addr net.IP) Caveat {
 		return ErrorCaveatf("bad IP address %d", []byte(addr))
 	}
 	return firstParty(CondClientIPAddr, addr.String())
+}
+
+// ClientOriginCaveat returns a caveat that will check whether the
+// client's Origin header in its HTTP request is as provided.
+func ClientOriginCaveat(origin string) Caveat {
+	return firstParty(CondClientOrigin, origin)
 }
 
 // ErrorCaveatf returns a caveat that will never be satisfied, holding

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -292,6 +292,17 @@ func (s *CheckersSuite) TestClientIPAddrCaveat(c *gc.C) {
 	})
 }
 
+func (s *CheckersSuite) TestClientOriginCaveat(c *gc.C) {
+	cav := checkers.ClientOriginCaveat("")
+	c.Assert(cav, gc.Equals, checkers.Caveat{
+		Condition: "origin ",
+	})
+	cav = checkers.ClientOriginCaveat("somewhere")
+	c.Assert(cav, gc.Equals, checkers.Caveat{
+		Condition: "origin somewhere",
+	})
+}
+
 var inferDeclaredTests = []struct {
 	about   string
 	caveats [][]checkers.Caveat

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -21,6 +21,7 @@ func Checkers(req *http.Request) checkers.Checker {
 	c := httpContext{req}
 	return checkers.Map{
 		checkers.CondClientIPAddr: c.clientIPAddr,
+		checkers.CondClientOrigin: c.clientOrigin,
 	}
 }
 
@@ -40,6 +41,15 @@ func (c httpContext) clientIPAddr(_, addr string) error {
 	}
 	if !reqIP.Equal(ip) {
 		return errgo.Newf("client IP address mismatch, got %s", reqIP)
+	}
+	return nil
+}
+
+// clientOrigin implements the Origin header checker
+// for an HTTP request.
+func (c httpContext) clientOrigin(_, origin string) error {
+	if reqOrigin := c.req.Header.Get("Origin"); reqOrigin != origin {
+		return errgo.Newf("request has invalid Origin header; got %q", reqOrigin)
 	}
 	return nil
 }

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -126,6 +126,28 @@ var checkerTests = []struct {
 		}).Condition,
 		expectError: `caveat "client-ip-addr 127.0.0.2" not satisfied: client IP address mismatch, got 2001:4860:0:2001::68`,
 	}},
+}, {
+	about:   "request with no origin",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{})),
+	checks: []checkTest{{
+		caveat: checkers.ClientOriginCaveat("").Condition,
+	}, {
+		caveat:      checkers.ClientOriginCaveat("somewhere").Condition,
+		expectError: `caveat "origin somewhere" not satisfied: request has invalid Origin header; got ""`,
+	}},
+}, {
+	about: "request with origin",
+	checker: checkers.New(httpbakery.Checkers(&http.Request{
+		Header: http.Header{
+			"Origin": {"somewhere"},
+		},
+	})),
+	checks: []checkTest{{
+		caveat:      checkers.ClientOriginCaveat("").Condition,
+		expectError: `caveat "origin " not satisfied: request has invalid Origin header; got "somewhere"`,
+	}, {
+		caveat: checkers.ClientOriginCaveat("somewhere").Condition,
+	}},
 }}
 
 func (s *CheckersSuite) TestCheckers(c *gc.C) {


### PR DESCRIPTION
This makes it straightforward for any HTTP server to add Origin first-party caveats.
