### PR TITLE
bakery: fix broken tests

### DIFF
--- a/bakery/service.go
+++ b/bakery/service.go
@@ -103,6 +103,7 @@ func (svc *Service) PublicKey() *PublicKey {
 // describes the error (other errors might be returned in other
 // circumstances).
 func (svc *Service) Check(ms macaroon.Slice, checker FirstPartyChecker) error {
+	logger.Infof("check with store %T %#v", svc.store)
 	if len(ms) == 0 {
 		return &VerificationError{
 			Reason: fmt.Errorf("no macaroons in slice"),
@@ -132,7 +133,7 @@ func (svc *Service) Check(ms macaroon.Slice, checker FirstPartyChecker) error {
 // CheckAnyM is like CheckAny except that on success it also returns
 // the set of macaroons that was successfully checked.
 // The "M" suffix is for backward compatibility reasons - in a
-// later bakery version, the signature of CheckRequest will be
+// later bakery version, the signature of CheckAny will be
 // changed to return the macaroon slice and CheckAnyM will be
 // removed.
 func (svc *Service) CheckAnyM(mss []macaroon.Slice, assert map[string]string, checker checkers.Checker) (map[string]string, macaroon.Slice, error) {
@@ -247,7 +248,6 @@ func LocalThirdPartyCaveat(key *PublicKey) checkers.Caveat {
 // encrypted with that public key. See LocalThirdPartyCaveat
 // for a way of creating such caveats.
 func (svc *Service) AddCaveat(m *macaroon.Macaroon, cav checkers.Caveat) error {
-	logger.Infof("Service.AddCaveat id %q; cav %#v", m.Id(), cav)
 	if cav.Location == "" {
 		m.AddFirstPartyCaveat(cav.Condition)
 		return nil

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -340,13 +340,13 @@ func (*ServiceSuite) TestCheckAny(c *gc.C) {
 	}, {
 		about: "one macaroon, no caveats",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x"),
+			newMacaroons("x1"),
 		},
-		expectId: "x",
+		expectId: "x1",
 	}, {
 		about: "one macaroon, one unrecognized caveat",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x", checkers.Caveat{
+			newMacaroons("x2", checkers.Caveat{
 				Condition: "bad",
 			}),
 		},
@@ -354,16 +354,16 @@ func (*ServiceSuite) TestCheckAny(c *gc.C) {
 	}, {
 		about: "two macaroons, only one ok",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x", checkers.Caveat{
+			newMacaroons("x3", checkers.Caveat{
 				Condition: "bad",
 			}),
-			newMacaroons("y"),
+			newMacaroons("y3"),
 		},
-		expectId: "y",
+		expectId: "y3",
 	}, {
 		about: "macaroon with declared caveats",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x",
+			newMacaroons("x4",
 				checkers.DeclaredCaveat("key1", "value1"),
 				checkers.DeclaredCaveat("key2", "value2"),
 			),
@@ -372,11 +372,11 @@ func (*ServiceSuite) TestCheckAny(c *gc.C) {
 			"key1": "value1",
 			"key2": "value2",
 		},
-		expectId: "x",
+		expectId: "x4",
 	}, {
 		about: "macaroon with declared values and asserted keys with wrong value",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x",
+			newMacaroons("x5",
 				checkers.DeclaredCaveat("key1", "value1"),
 				checkers.DeclaredCaveat("key2", "value2"),
 			),
@@ -384,12 +384,12 @@ func (*ServiceSuite) TestCheckAny(c *gc.C) {
 		assert: map[string]string{
 			"key1": "valuex",
 		},
-		expectId:    "x",
+		expectId:    "x5",
 		expectError: `verification failed: caveat "declared key1 value1" not satisfied: got key1="valuex", expected "value1"`,
 	}, {
 		about: "macaroon with declared values and asserted keys with correct value",
 		macaroons: []macaroon.Slice{
-			newMacaroons("x",
+			newMacaroons("x6",
 				checkers.DeclaredCaveat("key1", "value1"),
 				checkers.DeclaredCaveat("key2", "value2"),
 			),
@@ -401,8 +401,8 @@ func (*ServiceSuite) TestCheckAny(c *gc.C) {
 			"key1": "value1",
 			"key2": "value2",
 		},
-		expectId: "x",
-	}, {}}
+		expectId: "x6",
+	}}
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.about)
 		if test.expectDeclared == nil {


### PR DESCRIPTION
By using a fixed id in the test, we were associating several root keys with the
same id. Fix by using a different id in each test.
