### PR TITLE
httpbakery: add support for interaction method requests

### DIFF
--- a/httpbakery/browser.go
+++ b/httpbakery/browser.go
@@ -24,3 +24,17 @@ func OpenWebBrowser(url *url.URL) error {
 	}
 	return err
 }
+
+// WebBrowserVisitor holds an interactor that supports the "Interactive"
+// method by opening a web browser at the required location.
+var WebBrowserVisitor Visitor = webBrowserVisitor{}
+
+type webBrowserVisitor struct{}
+
+func (webBrowserVisitor) VisitWebPage(client *Client, methodURLs map[string]*url.URL) error {
+	u := methodURLs[UserInteractionMethod]
+	if u == nil {
+		return ErrMethodNotSupported
+	}
+	return OpenWebBrowser(u)
+}

--- a/httpbakery/visitor.go
+++ b/httpbakery/visitor.go
@@ -1,0 +1,123 @@
+package httpbakery
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/juju/httprequest"
+	"gopkg.in/errgo.v1"
+)
+
+// ErrMethodNotSupported is the error that a Visitor implementation
+// should return if it does not support any of the interaction methods.
+var ErrMethodNotSupported = errgo.New("interaction method not supported")
+
+// Visitor represents a handler that can handle ErrInteractionRequired
+// errors from a client's discharge request. The methodURLs parameter to
+// VisitWebPage holds a set of possible ways to complete the discharge
+// request. When called directly from Client, this will contain only a
+// single entry with the UserInteractionMethod key, specifying that the
+// associated URL should be opened in a web browser for the user to
+// interact with.
+//
+// See FallbackVisitor for a way to gain access to alternative methods.
+//
+// A Visitor implementation should return ErrMethodNotSupported if it
+// cannot handle any of the supplied methods.
+type Visitor interface {
+	VisitWebPage(client *Client, methodURLs map[string]*url.URL) error
+}
+
+const (
+	// UserInteractionMethod is the methodURLs key used for a URL
+	// that should be visited in a user's web browser. This is also
+	// the URL that can be used to fetch the available login methods
+	// (with an appropriate Accept header).
+	UserInteractionMethod = "interactive"
+)
+
+type multiVisitor struct {
+	supportedMethods []Visitor
+}
+
+// NewMultiVisitor returns a Visitor that queries the discharger for
+// available methods and then tries each of the given visitors in turn
+// until one succeeds or fails with an error cause other than
+// ErrMethodNotSupported.
+func NewMultiVisitor(methods ...Visitor) Visitor {
+	return &multiVisitor{
+		supportedMethods: methods,
+	}
+}
+
+// VisitWebPage implements Visitor.VisitWebPage by obtaining all the
+// available interaction methods and calling v.supportedMethods until it
+// finds one that recognizes the method.
+func (v multiVisitor) VisitWebPage(client *Client, methodURLs map[string]*url.URL) error {
+	// The Client implementation will always include a UserInteractionMethod
+	// entry taken from the VisitURL field in the error, so use that
+	// to find the set of supported interaction methods.
+	u := methodURLs[UserInteractionMethod]
+	if u == nil {
+		return errgo.Newf("cannot get interaction methods because no %q URL found", UserInteractionMethod)
+	}
+	if urls, err := GetInteractionMethods(client, u); err == nil {
+		// We succeeded in getting the set of interaction methods from
+		// the discharger. Use them.
+		methodURLs = urls
+		if methodURLs[UserInteractionMethod] == nil {
+			// There's no "interactive" method returned, but we know
+			// the server does actually support it, because all dischargers
+			// are required to, so fill it in with the original URL.
+			methodURLs[UserInteractionMethod] = u
+		}
+	} else {
+		logger.Debugf("ignoring error: cannot get interaction methods: %v", err)
+	}
+	// Go through all the Visitors, looking for one that supports one
+	// of the methods we have found.
+	for _, m := range v.supportedMethods {
+		err := m.VisitWebPage(client, methodURLs)
+		if err == nil {
+			return nil
+		}
+		if errgo.Cause(err) != ErrMethodNotSupported {
+			return errgo.Mask(err)
+		}
+	}
+	return errgo.Newf("no methods supported")
+}
+
+// GetInteractionMethods queries a URL as found in an
+// ErrInteractionRequired VisitURL field to find available interaction
+// methods.
+//
+// It does this by sending a GET request to the URL with the Accept
+// header set to "application/json" and parsing the resulting
+// response as a map[string]string.
+//
+// It uses the given Doer to execute the HTTP GET request.
+func GetInteractionMethods(client httprequest.Doer, u *url.URL) (map[string]*url.URL, error) {
+	httpReqClient := &httprequest.Client{
+		Doer: client,
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot create request")
+	}
+	req.Header.Set("Accept", "application/json")
+	var methodURLStrs map[string]string
+	if err := httpReqClient.Do(req, nil, &methodURLStrs); err != nil {
+		return nil, errgo.Mask(err)
+	}
+	// Make all the URLs relative to the request URL.
+	methodURLs := make(map[string]*url.URL)
+	for m, urlStr := range methodURLStrs {
+		relURL, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, errgo.Notef(err, "invalid URL for interaction method %q", m)
+		}
+		methodURLs[m] = u.ResolveReference(relURL)
+	}
+	return methodURLs, nil
+}

--- a/httpbakery/visitor_test.go
+++ b/httpbakery/visitor_test.go
@@ -1,0 +1,154 @@
+package httpbakery_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+)
+
+type VisitorSuite struct {
+	jujutesting.LoggingSuite
+}
+
+var _ = gc.Suite(&VisitorSuite{})
+
+func (*VisitorSuite) TestGetInteractionMethodsGetFailure(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte("failure"))
+	}))
+	defer srv.Close()
+
+	methods, err := httpbakery.GetInteractionMethods(http.DefaultClient, mustParseURL(srv.URL))
+	c.Assert(methods, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `GET .*: cannot unmarshal error response \(status 418 I'm a teapot\): unexpected content type text/plain; want application/json; content: failure`)
+}
+
+func (*VisitorSuite) TestGetInteractionMethodsSuccess(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"method": "http://somewhere/something"}`)
+	}))
+	defer srv.Close()
+
+	methods, err := httpbakery.GetInteractionMethods(http.DefaultClient, mustParseURL(srv.URL))
+	c.Assert(err, gc.IsNil)
+	c.Assert(methods, jc.DeepEquals, map[string]*url.URL{
+		"method": {
+			Scheme: "http",
+			Host:   "somewhere",
+			Path:   "/something",
+		},
+	})
+}
+
+func (*VisitorSuite) TestGetInteractionMethodsInvalidURL(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"method": ":::"}`)
+	}))
+	defer srv.Close()
+
+	methods, err := httpbakery.GetInteractionMethods(http.DefaultClient, mustParseURL(srv.URL))
+	c.Assert(methods, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `invalid URL for interaction method "method": parse :::: missing protocol scheme`)
+}
+
+func (*VisitorSuite) TestMultiVisitorNoUserInteractionMethod(c *gc.C) {
+	v := httpbakery.NewMultiVisitor()
+	err := v.VisitWebPage(httpbakery.NewClient(), nil)
+	c.Assert(err, gc.ErrorMatches, `cannot get interaction methods because no "interactive" URL found`)
+}
+
+func (*VisitorSuite) TestMultiVisitorNoInteractionMethods(c *gc.C) {
+	initialPage := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		initialPage++
+		fmt.Fprint(w, `<html>oh yes</html>`)
+	}))
+	defer srv.Close()
+	methods := map[string]*url.URL{
+		httpbakery.UserInteractionMethod: mustParseURL(srv.URL),
+	}
+	visited := 0
+	v := httpbakery.NewMultiVisitor(
+		visitorFunc(func(_ *httpbakery.Client, m map[string]*url.URL) error {
+			c.Check(m, jc.DeepEquals, methods)
+			visited++
+			return nil
+		}),
+	)
+	err := v.VisitWebPage(httpbakery.NewClient(), methods)
+	c.Assert(err, gc.IsNil)
+	c.Assert(initialPage, gc.Equals, 1)
+	c.Assert(visited, gc.Equals, 1)
+}
+
+func (*VisitorSuite) TestMultiVisitorSequence(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"method": "http://somewhere/something"}`)
+	}))
+	defer srv.Close()
+
+	firstCalled, secondCalled := 0, 0
+	v := httpbakery.NewMultiVisitor(
+		visitorFunc(func(_ *httpbakery.Client, m map[string]*url.URL) error {
+			c.Check(m["method"], gc.NotNil)
+			firstCalled++
+			return httpbakery.ErrMethodNotSupported
+		}),
+		visitorFunc(func(_ *httpbakery.Client, m map[string]*url.URL) error {
+			c.Check(m["method"], gc.NotNil)
+			secondCalled++
+			return nil
+		}),
+	)
+	err := v.VisitWebPage(httpbakery.NewClient(), map[string]*url.URL{
+		httpbakery.UserInteractionMethod: mustParseURL(srv.URL),
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(firstCalled, gc.Equals, 1)
+	c.Assert(secondCalled, gc.Equals, 1)
+}
+
+func (*VisitorSuite) TestUserInteractionFallback(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"method": "http://somewhere/something"}`)
+	}))
+	defer srv.Close()
+
+	called := 0
+	// Check that even though the methods didn't explicitly
+	// include the "interactive" method, it is still supplied.
+	v := httpbakery.NewMultiVisitor(
+		visitorFunc(func(_ *httpbakery.Client, m map[string]*url.URL) error {
+			c.Check(m, jc.DeepEquals, map[string]*url.URL{
+				"method": mustParseURL("http://somewhere/something"),
+				httpbakery.UserInteractionMethod: mustParseURL(srv.URL),
+			})
+			called++
+			return nil
+		}),
+	)
+	err := v.VisitWebPage(httpbakery.NewClient(), map[string]*url.URL{
+		httpbakery.UserInteractionMethod: mustParseURL(srv.URL),
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(called, gc.Equals, 1)
+}
+
+type visitorFunc func(*httpbakery.Client, map[string]*url.URL) error
+
+func (f visitorFunc) VisitWebPage(c *httpbakery.Client, m map[string]*url.URL) error {
+	return f(c, m)
+}


### PR DESCRIPTION
This formalises the interaction method request
protocol that already exists into httpbakery, making
it (hopefully) straightforward to mix and match
different kinds of discharge fulfillment interactions.

We also update the form package (backwardly incompatible
but we hope no-one's looking) to use the new
scheme. The agent package will be similarly updated
in a subsequent PR.
