### PR TITLE
mgostorage: add RootKeyStorage support

### DIFF
--- a/bakery/mgostorage/export_test.go
+++ b/bakery/mgostorage/export_test.go
@@ -1,0 +1,12 @@
+package mgostorage
+
+var (
+	TimeNow             = &timeNow
+	MgoCollectionFindId = &mgoCollectionFindId
+)
+
+type RootKey rootKey
+
+func IsValidWithPolicy(k RootKey, p Policy) bool {
+	return rootKey(k).isValidWithPolicy(p)
+}

--- a/bakery/mgostorage/rootkey.go
+++ b/bakery/mgostorage/rootkey.go
@@ -1,0 +1,348 @@
+package mgostorage
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/macaroon-bakery.v1/bakery"
+)
+
+// Functions defined as variables so they can be overidden
+// for testing.
+var (
+	timeNow = time.Now
+
+	mgoCollectionFindId = (*mgo.Collection).FindId
+)
+
+var logger = loggo.GetLogger("bakery.mgostorage")
+
+// maxPolicyCache holds the maximum number of storage policies that can
+// hold cached keys in a given RootKeys instance.
+//
+// 100 is probably overkill, given that practical systems will
+// likely only have a small number of active policies on any given
+// macaroon collection.
+const maxPolicyCache = 100
+
+// RootKeys represents a cache of macaroon root keys.
+type RootKeys struct {
+	maxCacheSize int
+
+	// TODO (rogpeppe) use RWMutex instead of Mutex here so that
+	// it's faster in the probably-common case that we
+	// have many contended readers.
+	mu       sync.Mutex
+	oldCache map[string]rootKey
+	cache    map[string]rootKey
+
+	// current holds the current root key for each storage policy.
+	current map[Policy]rootKey
+}
+
+type rootKey struct {
+	Id      string `bson:"_id"`
+	Created time.Time
+	Expires time.Time
+	RootKey []byte
+}
+
+// isValid reports whether the root key contains a key. Note that we
+// always generate non-empty root keys, so we use this to find
+// whether the root key is empty or not.
+func (rk rootKey) isValid() bool {
+	return rk.RootKey != nil
+}
+
+// isValidWithPolicy reports whether the given root key
+// is currently valid to use with the given storage policy.
+func (rk rootKey) isValidWithPolicy(p Policy) bool {
+	if !rk.isValid() {
+		return false
+	}
+	now := timeNow()
+	return afterEq(rk.Created, now.Add(-p.GenerateInterval)) &&
+		afterEq(rk.Expires, now.Add(p.ExpiryDuration)) &&
+		beforeEq(rk.Expires, now.Add(p.ExpiryDuration+p.GenerateInterval))
+}
+
+// NewRootKeys returns a root-keys cache that
+// is limited in size to approximately the given size.
+//
+// The NewStorageMethod returns a storage implementation
+// that uses a specific mongo collection and storage
+// policy.
+func NewRootKeys(maxCacheSize int) *RootKeys {
+	return &RootKeys{
+		maxCacheSize: maxCacheSize,
+		cache:        make(map[string]rootKey),
+		current:      make(map[Policy]rootKey),
+	}
+}
+
+// Policy holds a storage policy for root keys.
+type Policy struct {
+	// GenerateInterval holds the maximum length of time
+	// for which a root key will be returned from RootKey.
+	// If this is zero, it defaults to ExpiryDuration.
+	GenerateInterval time.Duration
+
+	// ExpiryDuration holds the minimum length of time that
+	// root keys will be valid for after they are returned from
+	// RootKey. The maximum length of time that they
+	// will be valid for is ExpiryDuration + GenerateInterval.
+	ExpiryDuration time.Duration
+}
+
+// NewStorage returns a new RootKeyStorage implementation that
+// stores and obtains root keys from the given collection.
+//
+// Root keys will be generated and stored following the
+// given storage policy.
+//
+// It is expected that all collections passed to a given RootKey's
+// NewStorage method should refer to the same underlying collection.
+func (s *RootKeys) NewStorage(c *mgo.Collection, policy Policy) bakery.RootKeyStorage {
+	if policy.GenerateInterval == 0 {
+		policy.GenerateInterval = policy.ExpiryDuration
+	}
+	return &rootKeyStorage{
+		keys:   s,
+		coll:   c,
+		policy: policy,
+	}
+}
+
+var indexes = []mgo.Index{{
+	Key: []string{"-created"},
+}, {
+	Key:         []string{"expires"},
+	ExpireAfter: time.Second,
+}}
+
+// EnsureIndex ensures that the required indexes exist on the
+// collection that will be used for root key storage.
+// This should be called at least once before using NewStorage.
+func (s *RootKeys) EnsureIndex(c *mgo.Collection) error {
+	for _, idx := range indexes {
+		if err := c.EnsureIndex(idx); err != nil {
+			return errgo.Notef(err, "cannot ensure index for %q on %q", idx.Key, c.Name)
+		}
+	}
+	return nil
+}
+
+// get gets the root key for the given id, trying the cache first and
+// falling back to calling fallback if it's not found there.
+//
+// If the key does not exist or has expired, it returns
+// bakery.ErrNotFound.
+//
+// Called with s.mu locked.
+func (s *RootKeys) get(id string, fallback func(id string) (rootKey, error)) (rootKey, error) {
+	key, cached, err := s.get0(id, fallback)
+	if err != nil && err != bakery.ErrNotFound {
+		return rootKey{}, errgo.Mask(err)
+	}
+	if err == nil && timeNow().After(key.Expires) {
+		key = rootKey{}
+		err = bakery.ErrNotFound
+	}
+	if !cached {
+		s.addCache(id, key)
+	}
+	return key, err
+}
+
+// get0 is the inner version of RootKeys.get. It returns an item and reports
+// whether it was found in the cache, but doesn't check whether the
+// item has expired or move the returned item to s.cache.
+func (s *RootKeys) get0(id string, fallback func(id string) (rootKey, error)) (key rootKey, inCache bool, err error) {
+	if k, ok := s.cache[id]; ok {
+		if !k.isValid() {
+			return rootKey{}, true, bakery.ErrNotFound
+		}
+		return k, true, nil
+	}
+	if k, ok := s.oldCache[id]; ok {
+		if !k.isValid() {
+			return rootKey{}, false, bakery.ErrNotFound
+		}
+		return k, false, nil
+	}
+	logger.Infof("cache miss for %q", id)
+	k, err := fallback(id)
+	return k, false, err
+}
+
+// addCache adds the given key to the cache.
+// Called with s.mu locked.
+func (s *RootKeys) addCache(id string, k rootKey) {
+	if len(s.cache) >= s.maxCacheSize {
+		s.oldCache = s.cache
+		s.cache = make(map[string]rootKey)
+	}
+	s.cache[id] = k
+}
+
+// setCurrent sets the current key for the given storage policy.
+// Called with s.mu locked.
+func (s *RootKeys) setCurrent(policy Policy, key rootKey) {
+	if len(s.current) > maxPolicyCache {
+		// Sanity check to avoid possibly memory leak:
+		// if some client is using arbitrarily many storage
+		// policies, we don't want s.keys.current to endlessly
+		// expand, so just kill the cache if it grows too big.
+		// This will result in worse performance but it shouldn't
+		// happen in practice and it's better than using endless
+		// space.
+		s.current = make(map[Policy]rootKey)
+	}
+	s.current[policy] = key
+}
+
+type rootKeyStorage struct {
+	keys   *RootKeys
+	policy Policy
+	coll   *mgo.Collection
+}
+
+// Get implements bakery.RootKeyStorage.Get.
+func (s *rootKeyStorage) Get(id string) ([]byte, error) {
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+
+	key, err := s.keys.get(id, s.getFromMongo)
+	if err != nil {
+		return nil, err
+	}
+	return key.RootKey, nil
+}
+
+func (s *rootKeyStorage) getFromMongo(id string) (rootKey, error) {
+	var key rootKey
+	err := mgoCollectionFindId(s.coll, id).One(&key)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return rootKey{}, bakery.ErrNotFound
+		}
+		return rootKey{}, errgo.Notef(err, "cannot get key from database")
+	}
+	return key, nil
+}
+
+// RootKey implements bakery.RootKeyStorage.RootKey by
+// returning an existing key from the cache when compatible
+// with the current policy.
+func (s *rootKeyStorage) RootKey() ([]byte, string, error) {
+	if key := s.rootKeyFromCache(); key.isValid() {
+		return key.RootKey, key.Id, nil
+	}
+	logger.Debugf("root key cache miss")
+	// Try to find a root key from the collection.
+	// It doesn't matter much if two concurrent mongo
+	// clients are doing this at the same time because
+	// we don't mind if there are more keys than necessary.
+	//
+	// Note that this query mirrors the logic found in
+	// rootKeyStorage.rootKeyFromCache.
+	now := timeNow()
+	var key rootKey
+	err := s.coll.Find(bson.D{{
+		"created", bson.D{{"$gte", now.Add(-s.policy.GenerateInterval)}},
+	}, {
+		"expires", bson.D{
+			{"$gte", now.Add(s.policy.ExpiryDuration)},
+			{"$lte", now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval)},
+		},
+	}}).Sort("-created").One(&key)
+	if err != nil && err != mgo.ErrNotFound {
+		return nil, "", errgo.Notef(err, "cannot query existing keys")
+	}
+	if !key.isValid() {
+		// No keys found anywhere, so let's create one.
+		var err error
+		key, err = s.generateKey()
+		if err != nil {
+			return nil, "", errgo.Notef(err, "cannot generate key")
+		}
+		logger.Infof("new root key id %q", key.Id)
+		if err := s.coll.Insert(key); err != nil {
+			return nil, "", errgo.Notef(err, "cannot create root key")
+		}
+	}
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+	s.keys.addCache(key.Id, key)
+	s.keys.setCurrent(s.policy, key)
+	return key.RootKey, key.Id, nil
+}
+
+// rootKeyFromCache returns a root key from the cached keys.
+// If no keys are found that are valid for s.policy, it returns
+// the zero key.
+func (s *rootKeyStorage) rootKeyFromCache() rootKey {
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+	if k, ok := s.keys.current[s.policy]; ok && k.isValidWithPolicy(s.policy) {
+		return k
+	}
+
+	// Find the most recently created key that's consistent with the
+	// storage policy.
+	var current rootKey
+	for _, k := range s.keys.cache {
+		if k.isValidWithPolicy(s.policy) && k.Created.After(current.Created) {
+			current = k
+		}
+	}
+	if current.isValid() {
+		s.keys.current[s.policy] = current
+		return current
+	}
+	return rootKey{}
+}
+
+func (s *rootKeyStorage) generateKey() (rootKey, error) {
+	newKey, err := randomBytes(24)
+	if err != nil {
+		return rootKey{}, err
+	}
+	newId, err := randomBytes(16)
+	if err != nil {
+		return rootKey{}, err
+	}
+	now := timeNow()
+	return rootKey{
+		Created: now,
+		Expires: now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval),
+		Id:      fmt.Sprintf("%x", newId),
+		RootKey: newKey,
+	}, nil
+}
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate %d random bytes: %v", n, err)
+	}
+	return b, nil
+}
+
+// afterEq reports whether t0 is after or equal to t1.
+func afterEq(t0, t1 time.Time) bool {
+	return !t0.Before(t1)
+}
+
+// beforeEq reports whether t1 is before or equal to t0.
+func beforeEq(t0, t1 time.Time) bool {
+	return !t0.After(t1)
+}

--- a/bakery/mgostorage/rootkey_test.go
+++ b/bakery/mgostorage/rootkey_test.go
@@ -1,0 +1,475 @@
+package mgostorage_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
+)
+
+type RootKeyStorageSuite struct {
+	testing.IsolatedMgoSuite
+}
+
+var _ = gc.Suite(&RootKeyStorageSuite{})
+
+var epoch = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+var isValidWithPolicyTests = []struct {
+	about  string
+	policy mgostorage.Policy
+	now    time.Time
+	key    mgostorage.RootKey
+	expect bool
+}{{
+	about: "success",
+	policy: mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   3 * time.Minute,
+	},
+	now: epoch.Add(20 * time.Minute),
+	key: mgostorage.RootKey{
+		Created: epoch.Add(19 * time.Minute),
+		Expires: epoch.Add(24 * time.Minute),
+		Id:      "id",
+		RootKey: []byte("key"),
+	},
+	expect: true,
+}, {
+	about: "empty root key",
+	policy: mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   3 * time.Minute,
+	},
+	now:    epoch.Add(20 * time.Minute),
+	key:    mgostorage.RootKey{},
+	expect: false,
+}, {
+	about: "created too early",
+	policy: mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   3 * time.Minute,
+	},
+	now: epoch.Add(20 * time.Minute),
+	key: mgostorage.RootKey{
+		Created: epoch.Add(18*time.Minute - time.Millisecond),
+		Expires: epoch.Add(24 * time.Minute),
+		Id:      "id",
+		RootKey: []byte("key"),
+	},
+	expect: false,
+}, {
+	about: "expires too early",
+	policy: mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   3 * time.Minute,
+	},
+	now: epoch.Add(20 * time.Minute),
+	key: mgostorage.RootKey{
+		Created: epoch.Add(19 * time.Minute),
+		Expires: epoch.Add(21 * time.Minute),
+		Id:      "id",
+		RootKey: []byte("key"),
+	},
+	expect: false,
+}, {
+	about: "expires too late",
+	policy: mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   3 * time.Minute,
+	},
+	now: epoch.Add(20 * time.Minute),
+	key: mgostorage.RootKey{
+		Created: epoch.Add(19 * time.Minute),
+		Expires: epoch.Add(25*time.Minute + time.Millisecond),
+		Id:      "id",
+		RootKey: []byte("key"),
+	},
+	expect: false,
+}}
+
+func (s *RootKeyStorageSuite) TestIsValidWithPolicy(c *gc.C) {
+	var now time.Time
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	for i, test := range isValidWithPolicyTests {
+		c.Logf("test %d: %v", i, test.about)
+		now = test.now
+		c.Assert(mgostorage.IsValidWithPolicy(test.key, test.policy), gc.Equals, test.expect)
+	}
+}
+
+func (s *RootKeyStorageSuite) TestRootKeyUsesKeysValidWithPolicy(c *gc.C) {
+	// We re-use the TestIsValidWithPolicy tests so that we
+	// know that the mongo logic uses the same behaviour.
+	var now time.Time
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	for i, test := range isValidWithPolicyTests {
+		c.Logf("test %d: %v", i, test.about)
+		if test.key.RootKey == nil {
+			// We don't store empty root keys in the database.
+			c.Logf("skipping test with empty root key")
+			continue
+		}
+		// Prime the collection with the root key document.
+		_, err := s.coll().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+		err = s.coll().Insert(test.key)
+		c.Assert(err, gc.IsNil)
+
+		store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), test.policy)
+		now = test.now
+		key, id, err := store.RootKey()
+		c.Assert(err, gc.IsNil)
+		if test.expect {
+			c.Assert(id, gc.Equals, "id")
+			c.Assert(string(key), gc.Equals, "key")
+		} else {
+			// If it didn't match then RootKey will have
+			// generated a new key.
+			c.Assert(key, gc.HasLen, 24)
+			c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+		}
+	}
+}
+
+func (s *RootKeyStorageSuite) TestRootKey(c *gc.C) {
+	now := epoch
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+
+	store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   5 * time.Minute,
+	})
+	key, id, err := store.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key, gc.HasLen, 24)
+	c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+
+	// If we get a key within the generate interval, we should
+	// get the same one.
+	now = epoch.Add(time.Minute)
+	key1, id1, err := store.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, gc.DeepEquals, key)
+	c.Assert(id1, gc.Equals, id)
+
+	// A different storage instance should get the same root key.
+	store1 := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
+		GenerateInterval: 2 * time.Minute,
+		ExpiryDuration:   5 * time.Minute,
+	})
+	key1, id1, err = store1.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, gc.DeepEquals, key)
+	c.Assert(id1, gc.Equals, id)
+
+	// After the generation interval has passed, we should generate a new key.
+	now = epoch.Add(2*time.Minute + time.Second)
+	key1, id1, err = store.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key, gc.HasLen, 24)
+	c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+	c.Assert(key1, gc.Not(gc.DeepEquals), key)
+	c.Assert(id1, gc.Not(gc.Equals), id)
+
+	// The other store should pick it up too.
+	key2, id2, err := store1.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key2, gc.DeepEquals, key1)
+	c.Assert(id2, gc.Equals, id1)
+}
+
+func (s *RootKeyStorageSuite) TestRootKeyDefaultGenerateInterval(c *gc.C) {
+	now := epoch
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
+		ExpiryDuration: 5 * time.Minute,
+	})
+	key, id, err := store.RootKey()
+	c.Assert(err, gc.IsNil)
+
+	now = epoch.Add(5 * time.Minute)
+	key1, id1, err := store.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, jc.DeepEquals, key)
+	c.Assert(id1, gc.Equals, id)
+
+	now = epoch.Add(5*time.Minute + time.Millisecond)
+	key1, id1, err = store.RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(key1, gc.Not(gc.DeepEquals), key)
+	c.Assert(id1, gc.Not(gc.Equals), id)
+}
+
+var preferredRootKeyTests = []struct {
+	about    string
+	now      time.Time
+	keys     []mgostorage.RootKey
+	policy   mgostorage.Policy
+	expectId string
+}{{
+	about: "latest creation time is preferred",
+	now:   epoch.Add(5 * time.Minute),
+	keys: []mgostorage.RootKey{{
+		Created: epoch.Add(4 * time.Minute),
+		Expires: epoch.Add(15 * time.Minute),
+		Id:      "id0",
+		RootKey: []byte("key0"),
+	}, {
+		Created: epoch.Add(5*time.Minute + 30*time.Second),
+		Expires: epoch.Add(16 * time.Minute),
+		Id:      "id1",
+		RootKey: []byte("key1"),
+	}, {
+		Created: epoch.Add(5 * time.Minute),
+		Expires: epoch.Add(16 * time.Minute),
+		Id:      "id2",
+		RootKey: []byte("key2"),
+	}},
+	policy: mgostorage.Policy{
+		GenerateInterval: 5 * time.Minute,
+		ExpiryDuration:   7 * time.Minute,
+	},
+	expectId: "id1",
+}, {
+	about: "ineligible keys are exluded",
+	now:   epoch.Add(5 * time.Minute),
+	keys: []mgostorage.RootKey{{
+		Created: epoch.Add(4 * time.Minute),
+		Expires: epoch.Add(15 * time.Minute),
+		Id:      "id0",
+		RootKey: []byte("key0"),
+	}, {
+		Created: epoch.Add(5 * time.Minute),
+		Expires: epoch.Add(16*time.Minute + 30*time.Second),
+		Id:      "id1",
+		RootKey: []byte("key1"),
+	}, {
+		Created: epoch.Add(6 * time.Minute),
+		Expires: epoch.Add(time.Hour),
+		Id:      "id2",
+		RootKey: []byte("key2"),
+	}},
+	policy: mgostorage.Policy{
+		GenerateInterval: 5 * time.Minute,
+		ExpiryDuration:   7 * time.Minute,
+	},
+	expectId: "id1",
+}}
+
+func (s *RootKeyStorageSuite) TestPreferredRootKeyFromDatabase(c *gc.C) {
+	var now time.Time
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	for i, test := range preferredRootKeyTests {
+		c.Logf("%d: %v", i, test.about)
+		_, err := s.coll().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+		for _, key := range test.keys {
+			err := s.coll().Insert(key)
+			c.Assert(err, gc.IsNil)
+		}
+		store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), test.policy)
+		now = test.now
+		_, id, err := store.RootKey()
+		c.Assert(err, gc.IsNil)
+		c.Assert(id, gc.Equals, test.expectId)
+	}
+}
+
+func (s *RootKeyStorageSuite) TestPreferredRootKeyFromCache(c *gc.C) {
+	var now time.Time
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	for i, test := range preferredRootKeyTests {
+		c.Logf("%d: %v", i, test.about)
+		for _, key := range test.keys {
+			err := s.coll().Insert(key)
+			c.Assert(err, gc.IsNil)
+		}
+		store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), test.policy)
+		// Ensure that all the keys are in cache by getting all of them.
+		for _, key := range test.keys {
+			got, err := store.Get(key.Id)
+			c.Assert(err, gc.IsNil)
+			c.Assert(got, jc.DeepEquals, key.RootKey)
+		}
+		// Remove all the keys from the collection so that
+		// we know we must be acquiring them from the cache.
+		_, err := s.coll().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+
+		// Test that RootKey returns the expected key.
+		now = test.now
+		_, id, err := store.RootKey()
+		c.Assert(err, gc.IsNil)
+		c.Assert(id, gc.Equals, test.expectId)
+	}
+}
+
+func (s *RootKeyStorageSuite) TestGet(c *gc.C) {
+	now := epoch
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+
+	store := mgostorage.NewRootKeys(5).NewStorage(s.coll(), mgostorage.Policy{
+		GenerateInterval: 1 * time.Minute,
+		ExpiryDuration:   30 * time.Minute,
+	})
+	type idKey struct {
+		id  string
+		key []byte
+	}
+	var keys []idKey
+	keyIds := make(map[string]bool)
+	for i := 0; i < 20; i++ {
+		key, id, err := store.RootKey()
+		c.Assert(err, gc.IsNil)
+		c.Assert(keyIds[id], gc.Equals, false)
+		keys = append(keys, idKey{id, key})
+		now = now.Add(time.Minute + time.Second)
+	}
+	for i, k := range keys {
+		key, err := store.Get(k.id)
+		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
+		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
+	}
+	// Check that the keys are cached.
+	//
+	// Since the cache size is 5, the most recent 5 items will be in
+	// the primary cache; the 5 items before that will be in the old
+	// cache and nothing else will be cached.
+	//
+	// The first time we fetch an item from the old cache, a new
+	// primary cache will be allocated, all existing items in the
+	// old cache except that item will be evicted, and all items in
+	// the current primary cache moved to the old cache.
+	//
+	// The upshot of that is that all but the first 6 calls to Get
+	// should result in a database fetch.
+
+	var fetched []string
+	s.PatchValue(mgostorage.MgoCollectionFindId, func(coll *mgo.Collection, id interface{}) *mgo.Query {
+		fetched = append(fetched, id.(string))
+		return coll.FindId(id)
+	})
+	c.Logf("testing cache")
+
+	for i := len(keys) - 1; i >= 0; i-- {
+		k := keys[i]
+		key, err := store.Get(k.id)
+		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
+		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
+	}
+	c.Assert(len(fetched), gc.Equals, len(keys)-6)
+	for i, id := range fetched {
+		c.Assert(id, gc.Equals, keys[len(keys)-6-i-1].id)
+	}
+}
+
+func (s *RootKeyStorageSuite) TestGetCachesMisses(c *gc.C) {
+	store := mgostorage.NewRootKeys(5).NewStorage(s.coll(), mgostorage.Policy{
+		GenerateInterval: 1 * time.Minute,
+		ExpiryDuration:   30 * time.Minute,
+	})
+	var fetched []string
+	s.PatchValue(mgostorage.MgoCollectionFindId, func(coll *mgo.Collection, id interface{}) *mgo.Query {
+		fetched = append(fetched, id.(string))
+		return coll.FindId(id)
+	})
+	key, err := store.Get("foo")
+	c.Assert(err, gc.Equals, bakery.ErrNotFound)
+	c.Assert(key, gc.IsNil)
+	c.Assert(fetched, jc.DeepEquals, []string{"foo"})
+	fetched = nil
+
+	key, err = store.Get("foo")
+	c.Assert(err, gc.Equals, bakery.ErrNotFound)
+	c.Assert(key, gc.IsNil)
+	c.Assert(fetched, gc.IsNil)
+}
+
+func (s *RootKeyStorageSuite) TestGetExpiredItemFromCache(c *gc.C) {
+	now := epoch
+	s.PatchValue(mgostorage.TimeNow, func() time.Time {
+		return now
+	})
+	store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
+		ExpiryDuration: 5 * time.Minute,
+	})
+	_, id, err := store.RootKey()
+	c.Assert(err, gc.IsNil)
+
+	s.PatchValue(mgostorage.MgoCollectionFindId, func(*mgo.Collection, interface{}) *mgo.Query {
+		c.Errorf("FindId unexpectedly called")
+		return nil
+	})
+
+	now = epoch.Add(15 * time.Minute)
+
+	_, err = store.Get(id)
+	c.Assert(err, gc.Equals, bakery.ErrNotFound)
+}
+
+func (s *RootKeyStorageSuite) TestEnsureIndex(c *gc.C) {
+	keys := mgostorage.NewRootKeys(5)
+	err := keys.EnsureIndex(s.coll())
+	c.Assert(err, gc.IsNil)
+
+	// This code can take up to 60s to run; there's no way
+	// to force it to run more quickly, but it provides reassurance
+	// that the code actually works.
+	// Reenable the rest of this test if concerned about index behaviour.
+
+	c.SucceedNow()
+
+	_, id1, err := keys.NewStorage(s.coll(), mgostorage.Policy{
+		ExpiryDuration: 100 * time.Millisecond,
+	}).RootKey()
+	c.Assert(err, gc.IsNil)
+
+	_, id2, err := keys.NewStorage(s.coll(), mgostorage.Policy{
+		ExpiryDuration: time.Hour,
+	}).RootKey()
+	c.Assert(err, gc.IsNil)
+	c.Assert(id2, gc.Not(gc.Equals), id1)
+
+	// Sanity check that the keys are in the collection.
+	n, err := s.coll().Find(nil).Count()
+	c.Assert(err, gc.IsNil)
+	c.Assert(n, gc.Equals, 2)
+	for i := 0; i < 100; i++ {
+		n, err := s.coll().Find(nil).Count()
+		c.Assert(err, gc.IsNil)
+		switch n {
+		case 1:
+			c.SucceedNow()
+		case 2:
+			time.Sleep(time.Second)
+		default:
+			c.Fatalf("unexpected key count %v", n)
+		}
+	}
+	c.Fatalf("key was never removed from database")
+}
+
+func (s *RootKeyStorageSuite) coll() *mgo.Collection {
+	return s.Session.DB("test").C("items")
+}


### PR DESCRIPTION
This means that we can use the same underlying collection for
both long-lived and short-lived macaroon root keys, and use
the cache for almost all accesses.
