### PR TITLE
httpbakery: use latest version rather than zero

### DIFF
--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -285,9 +285,14 @@ func versionFromRequest(req *http.Request) version {
 		return version0
 	}
 	v, err := strconv.Atoi(vs)
-	if err != nil || version(v) < 0 || version(v) > latestVersion {
+	if err != nil || version(v) < 0 {
 		// Badly formed header - use backward compatibility mode.
 		return version0
+	}
+	if version(v) > latestVersion {
+		// Later version than we know about - use the
+		// latest version that we can.
+		return latestVersion
 	}
 	return version(v)
 }


### PR DESCRIPTION
This means that when we move to using a later version,
old servers will use the latest version they support rather
than falling back to version 0.

We should make sure that all servers incorporate this change
before starting to migrate to the new bakery/macaroons standards.
