### PR TITLE
all: new v2-unstable version

### DIFF
--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -8,10 +8,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type CheckersSuite struct{}
@@ -415,13 +415,13 @@ func (*CheckersSuite) TestInferDeclared(c *gc.C) {
 		c.Logf("test %d: %s", i, test.about)
 		ms := make(macaroon.Slice, len(test.caveats))
 		for i, caveats := range test.caveats {
-			m, err := macaroon.New(nil, fmt.Sprint(i), "")
+			m, err := macaroon.New(nil, []byte(fmt.Sprint(i)), "")
 			c.Assert(err, gc.IsNil)
 			for _, cav := range caveats {
 				if cav.Location == "" {
 					m.AddFirstPartyCaveat(cav.Condition)
 				} else {
-					m.AddThirdPartyCaveat(nil, cav.Condition, cav.Location)
+					m.AddThirdPartyCaveat(nil, []byte(cav.Condition), cav.Location)
 				}
 			}
 			ms[i] = m

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 // DeclaredCaveat returns a "declared" caveat asserting that the given key is
@@ -84,7 +84,7 @@ func InferDeclared(ms macaroon.Slice) Declared {
 			if cav.Location != "" {
 				continue
 			}
-			name, rest, err := ParseCaveat(cav.Id)
+			name, rest, err := ParseCaveat(string(cav.Id))
 			if err != nil {
 				continue
 			}

--- a/bakery/checkers/time.go
+++ b/bakery/checkers/time.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 var timeNow = time.Now
@@ -39,10 +39,11 @@ func ExpiryTime(cavs []macaroon.Caveat) (time.Time, bool) {
 	var t time.Time
 	var expires bool
 	for _, cav := range cavs {
-		if !strings.HasPrefix(cav.Id, CondTimeBefore) {
+		cond := string(cav.Id)
+		if !strings.HasPrefix(cond, CondTimeBefore) {
 			continue
 		}
-		et, err := time.Parse(CondTimeBefore+" "+time.RFC3339Nano, cav.Id)
+		et, err := time.Parse(CondTimeBefore+" "+time.RFC3339Nano, cond)
 		if err != nil {
 			continue
 		}

--- a/bakery/checkers/time_test.go
+++ b/bakery/checkers/time_test.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type timeSuite struct{}
@@ -31,7 +31,7 @@ var expireTimeTests = []struct {
 	about: "single time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 	},
 	expectTime:    t1,
@@ -40,17 +40,17 @@ var expireTimeTests = []struct {
 	about: "single deny caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.DenyCaveat("abc").Condition,
+			Id: []byte(checkers.DenyCaveat("abc").Condition),
 		},
 	},
 }, {
 	about: "multiple time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t2).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t2).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 	},
 	expectTime:    t1,
@@ -59,16 +59,16 @@ var expireTimeTests = []struct {
 	about: "mixed caveats",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.AllowCaveat("abc").Condition,
+			Id: []byte(checkers.AllowCaveat("abc").Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t2).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t2).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.DenyCaveat("def").Condition,
+			Id: []byte(checkers.DenyCaveat("def").Condition),
 		},
 	},
 	expectTime:    t1,
@@ -77,7 +77,7 @@ var expireTimeTests = []struct {
 	about: "invalid time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.CondTimeBefore + " tomorrow",
+			Id: []byte(checkers.CondTimeBefore + " tomorrow"),
 		},
 	},
 }}
@@ -157,7 +157,7 @@ func (s *timeSuite) TestMacaroonsExpireTime(c *gc.C) {
 }
 
 func mustNewMacaroon(cavs ...string) *macaroon.Macaroon {
-	m, err := macaroon.New(nil, "", "")
+	m, err := macaroon.New(nil, nil, "")
 	if err != nil {
 		panic(err)
 	}

--- a/bakery/codec.go
+++ b/bakery/codec.go
@@ -12,12 +12,6 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-type caveatInfo struct {
-	peerPublicKey *PublicKey
-	rootKey       []byte
-	condition     string
-}
-
 type caveatIdRecord struct {
 	RootKey   []byte
 	Condition string
@@ -32,22 +26,27 @@ type caveatId struct {
 }
 
 // encodeJSONCaveatId creates a JSON encoded third-party caveat.
-func encodeJSONCaveatId(key *KeyPair, ci caveatInfo) ([]byte, error) {
+func encodeJSONCaveatId(
+	condition string,
+	rootKey []byte,
+	thirdPartyPub *PublicKey,
+	key *KeyPair,
+) ([]byte, error) {
 	var nonce [NonceLen]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return nil, errgo.Notef(err, "cannot generate random number for nonce")
 	}
 	plain := caveatIdRecord{
-		RootKey:   ci.rootKey,
-		Condition: ci.condition,
+		RootKey:   rootKey,
+		Condition: condition,
 	}
 	plainData, err := json.Marshal(&plain)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot marshal %#v", &plain)
 	}
-	sealed := box.Seal(nil, plainData, &nonce, ci.peerPublicKey.boxKey(), key.Private.boxKey())
+	sealed := box.Seal(nil, plainData, &nonce, thirdPartyPub.boxKey(), key.Private.boxKey())
 	id := caveatId{
-		ThirdPartyPublicKey: ci.peerPublicKey,
+		ThirdPartyPublicKey: thirdPartyPub,
 		FirstPartyPublicKey: &key.Public,
 		Nonce:               nonce[:],
 		Id:                  base64.StdEncoding.EncodeToString(sealed),
@@ -61,9 +60,7 @@ func encodeJSONCaveatId(key *KeyPair, ci caveatInfo) ([]byte, error) {
 	return buf, nil
 }
 
-const (
-	publicKeyPrefixLen = 4
-)
+const publicKeyPrefixLen = 4
 
 // encodeCaveatIdV0 creates a version 0 third-party caveat.
 //
@@ -73,17 +70,23 @@ const (
 // first-party Curve25519 public key [32 bytes]
 // nonce [24 bytes]
 // encrypted secret part [rest of message]
-func encodeCaveatIdV0(key *KeyPair, ci caveatInfo) ([]byte, error) {
+func encodeCaveatIdV0(
+	condition string,
+	rootKey []byte,
+	thirdPartyPub *PublicKey,
+	key *KeyPair,
+) ([]byte, error) {
 	var nonce [NonceLen]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return nil, errgo.Notef(err, "cannot generate random number for nonce")
 	}
-	data := make([]byte, 0, 1+publicKeyPrefixLen+KeyLen+NonceLen+1+binary.MaxVarintLen64+len(ci.rootKey)+len(ci.condition)+box.Overhead)
+	data := make([]byte, 0, 1+publicKeyPrefixLen+KeyLen+NonceLen+1+binary.MaxVarintLen64+len(rootKey)+len(condition)+box.Overhead)
 	data = append(data, 0) //version
-	data = append(data, ci.peerPublicKey.Key[:publicKeyPrefixLen]...)
+	data = append(data, thirdPartyPub.Key[:publicKeyPrefixLen]...)
 	data = append(data, key.Public.Key[:]...)
 	data = append(data, nonce[:]...)
-	data = box.Seal(data, encodeSecretPartV0(ci), &nonce, ci.peerPublicKey.boxKey(), key.Private.boxKey())
+	secret := encodeSecretPartV0(condition, rootKey)
+	data = box.Seal(data, secret, &nonce, thirdPartyPub.boxKey(), key.Private.boxKey())
 	return data, nil
 }
 
@@ -94,21 +97,21 @@ func encodeCaveatIdV0(key *KeyPair, ci caveatInfo) ([]byte, error) {
 // version 0 [1 byte]
 // root key [24 bytes]
 // predicate [rest of message]
-func encodeSecretPartV0(ci caveatInfo) []byte {
-	data := make([]byte, 0, 1+binary.MaxVarintLen64+len(ci.rootKey)+len(ci.condition))
+func encodeSecretPartV0(condition string, rootKey []byte) []byte {
+	data := make([]byte, 0, 1+binary.MaxVarintLen64+len(rootKey)+len(condition))
 	data = append(data, 0) // version
-	n := binary.PutUvarint(data[1:1+binary.MaxVarintLen64], uint64(len(ci.rootKey)))
+	n := binary.PutUvarint(data[1:1+binary.MaxVarintLen64], uint64(len(rootKey)))
 	data = data[0 : len(data)+n]
-	data = append(data, ci.rootKey...)
-	data = append(data, ci.condition...)
+	data = append(data, rootKey...)
+	data = append(data, condition...)
 	return data
 }
 
 // decodeCaveatId attempts to decode id decrypting the encrypted part
 // using key.
-func decodeCaveatId(key *KeyPair, id []byte) (caveatInfo, error) {
+func decodeCaveatId(key *KeyPair, id []byte) (*ThirdPartyCaveatInfo, error) {
 	if len(id) == 0 {
-		return caveatInfo{}, errgo.New("caveat id empty")
+		return nil, errgo.New("caveat id empty")
 	}
 	switch id[0] {
 	case 0:
@@ -117,103 +120,111 @@ func decodeCaveatId(key *KeyPair, id []byte) (caveatInfo, error) {
 		// 'e' will be the first byte if the caveatid is a base64 encoded JSON object.
 		return decodeJSONCaveatId(key, id)
 	default:
-		return caveatInfo{}, errgo.Newf("caveat id has unsupported version %d", id[0])
+		return nil, errgo.Newf("caveat id has unsupported version %d", id[0])
 	}
 }
 
 // decodeJSONCaveatId attempts to decode a base64 encoded JSON id. This
 // encoding is nominally version -1.
-func decodeJSONCaveatId(key *KeyPair, id []byte) (caveatInfo, error) {
+func decodeJSONCaveatId(key *KeyPair, id []byte) (*ThirdPartyCaveatInfo, error) {
 	data := make([]byte, (3*len(id)+3)/4)
 	n, err := base64.StdEncoding.Decode(data, id)
 	if err != nil {
-		return caveatInfo{}, errgo.Notef(err, "cannot base64-decode caveat id")
+		return nil, errgo.Notef(err, "cannot base64-decode caveat id")
 	}
 	data = data[:n]
 	var tpid caveatId
 	if err := json.Unmarshal(data, &tpid); err != nil {
-		return caveatInfo{}, errgo.Notef(err, "cannot unmarshal caveat id %q", data)
+		return nil, errgo.Notef(err, "cannot unmarshal caveat id %q", data)
 	}
 	if !bytes.Equal(key.Public.Key[:], tpid.ThirdPartyPublicKey.Key[:]) {
-		return caveatInfo{}, errgo.New("public key mismatch")
+		return nil, errgo.New("public key mismatch")
 	}
 	if tpid.FirstPartyPublicKey == nil {
-		return caveatInfo{}, errgo.New("target service public key not specified")
+		return nil, errgo.New("target service public key not specified")
 	}
 	// The encrypted string is base64 encoded in the JSON representation.
 	secret, err := base64.StdEncoding.DecodeString(tpid.Id)
 	if err != nil {
-		return caveatInfo{}, errgo.Notef(err, "cannot base64-decode encrypted data")
+		return nil, errgo.Notef(err, "cannot base64-decode encrypted data")
 	}
 	var nonce [NonceLen]byte
 	if copy(nonce[:], tpid.Nonce) < NonceLen {
-		return caveatInfo{}, errgo.Newf("nonce too short %x", tpid.Nonce)
+		return nil, errgo.Newf("nonce too short %x", tpid.Nonce)
 	}
 	cid, ok := box.Open(nil, secret, &nonce, tpid.FirstPartyPublicKey.boxKey(), key.Private.boxKey())
 	if !ok {
-		return caveatInfo{}, errgo.Newf("cannot decrypt caveat id %#v", tpid)
+		return nil, errgo.Newf("cannot decrypt caveat id %#v", tpid)
 	}
 	var record caveatIdRecord
 	if err := json.Unmarshal(cid, &record); err != nil {
-		return caveatInfo{}, errgo.Notef(err, "cannot decode third party caveat record")
+		return nil, errgo.Notef(err, "cannot decode third party caveat record")
 	}
-	return caveatInfo{
-		peerPublicKey: tpid.FirstPartyPublicKey,
-		rootKey:       record.RootKey,
-		condition:     record.Condition,
+	return &ThirdPartyCaveatInfo{
+		Condition:           record.Condition,
+		FirstPartyPublicKey: *tpid.FirstPartyPublicKey,
+		ThirdPartyKeyPair:   *key,
+		RootKey:             record.RootKey,
+		CaveatId:            id,
+		MacaroonId:          id,
 	}, nil
 }
 
 // decodeCaveatIdV0 decodes a version 0 caveat id.
-func decodeCaveatIdV0(key *KeyPair, id []byte) (caveatInfo, error) {
+func decodeCaveatIdV0(key *KeyPair, id []byte) (*ThirdPartyCaveatInfo, error) {
+	origId := id
 	if len(id) < 1+publicKeyPrefixLen+KeyLen+NonceLen+box.Overhead {
-		return caveatInfo{}, errgo.New("caveat id too short")
+		return nil, errgo.New("caveat id too short")
 	}
 	id = id[1:] // skip version (already checked)
 
 	publicKeyPrefix, id := id[:publicKeyPrefixLen], id[publicKeyPrefixLen:]
 	if !bytes.Equal(key.Public.Key[:publicKeyPrefixLen], publicKeyPrefix) {
-		return caveatInfo{}, errgo.New("public key mismatch")
+		return nil, errgo.New("public key mismatch")
 	}
 
-	var peerPublicKey PublicKey
-	copy(peerPublicKey.Key[:], id[:KeyLen])
+	var firstPartyPub PublicKey
+	copy(firstPartyPub.Key[:], id[:KeyLen])
 	id = id[KeyLen:]
 
 	var nonce [NonceLen]byte
 	copy(nonce[:], id[:NonceLen])
 	id = id[NonceLen:]
 
-	data, ok := box.Open(nil, id, &nonce, peerPublicKey.boxKey(), key.Private.boxKey())
+	data, ok := box.Open(nil, id, &nonce, firstPartyPub.boxKey(), key.Private.boxKey())
 	if !ok {
-		return caveatInfo{}, errgo.Newf("cannot decrypt caveat id")
+		return nil, errgo.Newf("cannot decrypt caveat id")
 	}
-	ci, err := decodeSecretPartV0(data)
+	rootKey, condition, err := decodeSecretPartV0(data)
 	if err != nil {
-		return caveatInfo{}, errgo.Notef(err, "invalid secret part")
+		return nil, errgo.Notef(err, "invalid secret part")
 	}
-	ci.peerPublicKey = &peerPublicKey
-	return ci, nil
+	return &ThirdPartyCaveatInfo{
+		Condition:           condition,
+		FirstPartyPublicKey: firstPartyPub,
+		ThirdPartyKeyPair:   *key,
+		RootKey:             rootKey,
+		CaveatId:            origId,
+		MacaroonId:          origId,
+	}, nil
 }
 
-func decodeSecretPartV0(data []byte) (caveatInfo, error) {
+func decodeSecretPartV0(data []byte) (rootKey []byte, condition string, err error) {
 	if len(data) < 1 {
-		return caveatInfo{}, errgo.New("secret part too short")
+		return nil, "", errgo.New("secret part too short")
 	}
 
 	version, data := data[0], data[1:]
 	if version != 0 {
-		return caveatInfo{}, errgo.Newf("unsupported secret part version %d", version)
+		return nil, "", errgo.Newf("unsupported secret part version %d", version)
 	}
 
 	l, n := binary.Uvarint(data)
 	if n <= 0 || uint64(n)+l > uint64(len(data)) {
-		return caveatInfo{}, errgo.Newf("invalid root key length")
+		return nil, "", errgo.Newf("invalid root key length")
 	}
 	data = data[n:]
 
-	return caveatInfo{
-		rootKey:   data[:l],
-		condition: string(data[l:]),
-	}, nil
+	rootKey, condition = data[:l], string(data[l:])
+	return rootKey, condition, nil
 }

--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // authService implements an authorization service,
@@ -31,8 +31,8 @@ func authService(endpoint string, key *bakery.KeyPair) (http.Handler, error) {
 //
 // Note how this function can return additional first- and third-party
 // caveats which will be added to the original macaroon's caveats.
-func thirdPartyChecker(req *http.Request, cavId, condition string) ([]checkers.Caveat, error) {
-	if condition != "access-allowed" {
+func thirdPartyChecker(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+	if cav.Condition != "access-allowed" {
 		return nil, checkers.ErrCaveatNotRecognized
 	}
 	// TODO check that the HTTP request has cookies that prove

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // client represents a client of the target service.

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 func TestPackage(t *testing.T) {

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -13,9 +13,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/example/idservice"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/idservice"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type suite struct {

--- a/bakery/example/idservice/meeting.go
+++ b/bakery/example/idservice/meeting.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/meeting"
 )
 
 type thirdPartyCaveatInfo struct {
-	CaveatId string
+	CaveatId []byte
 	Caveat   string
 }
 

--- a/bakery/example/idservice/targetservice_test.go
+++ b/bakery/example/idservice/targetservice_test.go
@@ -7,9 +7,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type targetServiceHandler struct {
@@ -108,7 +108,7 @@ func (srv *targetServiceHandler) writeError(w http.ResponseWriter, req *http.Req
 		Condition: "operation " + operation,
 	}}
 	// Mint an appropriate macaroon and send it back to the client.
-	m, err := srv.svc.NewMacaroon("", nil, caveats)
+	m, err := srv.svc.NewMacaroon(nil, nil, caveats)
 	if err != nil {
 		fail(http.StatusInternalServerError, "cannot mint macaroon: %v", err)
 		return

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -24,8 +24,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var defaultHTTPClient = httpbakery.NewHTTPClient()

--- a/bakery/example/meeting/meeting_test.go
+++ b/bakery/example/meeting/meeting_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/meeting"
 )
 
 type suite struct{}

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -8,9 +8,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type targetServiceHandler struct {
@@ -113,7 +113,7 @@ func (srv *targetServiceHandler) writeError(w http.ResponseWriter, req *http.Req
 			Condition: "operation " + operation,
 		}}
 	// Mint an appropriate macaroon and send it back to the client.
-	m, err := srv.svc.NewMacaroon("", nil, caveats)
+	m, err := srv.svc.NewMacaroon(nil, nil, caveats)
 	if err != nil {
 		fail(http.StatusInternalServerError, "cannot mint macaroon: %v", err)
 		return

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 type KeysSuite struct{}

--- a/bakery/mgostorage/rootkey.go
+++ b/bakery/mgostorage/rootkey.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 // Functions defined as variables so they can be overidden
@@ -48,7 +48,7 @@ type RootKeys struct {
 }
 
 type rootKey struct {
-	Id      string `bson:"_id"`
+	Id      []byte `bson:"_id"`
 	Created time.Time
 	Expires time.Time
 	RootKey []byte
@@ -146,7 +146,7 @@ func (s *RootKeys) EnsureIndex(c *mgo.Collection) error {
 // bakery.ErrNotFound.
 //
 // Called with s.mu locked.
-func (s *RootKeys) get(id string, fallback func(id string) (rootKey, error)) (rootKey, error) {
+func (s *RootKeys) get(id []byte, fallback func(id []byte) (rootKey, error)) (rootKey, error) {
 	key, cached, err := s.get0(id, fallback)
 	if err != nil && err != bakery.ErrNotFound {
 		return rootKey{}, errgo.Mask(err)
@@ -164,14 +164,14 @@ func (s *RootKeys) get(id string, fallback func(id string) (rootKey, error)) (ro
 // get0 is the inner version of RootKeys.get. It returns an item and reports
 // whether it was found in the cache, but doesn't check whether the
 // item has expired or move the returned item to s.cache.
-func (s *RootKeys) get0(id string, fallback func(id string) (rootKey, error)) (key rootKey, inCache bool, err error) {
-	if k, ok := s.cache[id]; ok {
+func (s *RootKeys) get0(id []byte, fallback func(id []byte) (rootKey, error)) (key rootKey, inCache bool, err error) {
+	if k, ok := s.cache[string(id)]; ok {
 		if !k.isValid() {
 			return rootKey{}, true, bakery.ErrNotFound
 		}
 		return k, true, nil
 	}
-	if k, ok := s.oldCache[id]; ok {
+	if k, ok := s.oldCache[string(id)]; ok {
 		if !k.isValid() {
 			return rootKey{}, false, bakery.ErrNotFound
 		}
@@ -184,12 +184,12 @@ func (s *RootKeys) get0(id string, fallback func(id string) (rootKey, error)) (k
 
 // addCache adds the given key to the cache.
 // Called with s.mu locked.
-func (s *RootKeys) addCache(id string, k rootKey) {
+func (s *RootKeys) addCache(id []byte, k rootKey) {
 	if len(s.cache) >= s.maxCacheSize {
 		s.oldCache = s.cache
 		s.cache = make(map[string]rootKey)
 	}
-	s.cache[id] = k
+	s.cache[string(id)] = k
 }
 
 // setCurrent sets the current key for the given storage policy.
@@ -215,7 +215,7 @@ type rootKeyStorage struct {
 }
 
 // Get implements bakery.RootKeyStorage.Get.
-func (s *rootKeyStorage) Get(id string) ([]byte, error) {
+func (s *rootKeyStorage) Get(id []byte) ([]byte, error) {
 	s.keys.mu.Lock()
 	defer s.keys.mu.Unlock()
 
@@ -226,7 +226,23 @@ func (s *rootKeyStorage) Get(id string) ([]byte, error) {
 	return key.RootKey, nil
 }
 
-func (s *rootKeyStorage) getFromMongo(id string) (rootKey, error) {
+func (s *rootKeyStorage) getFromMongo(id []byte) (rootKey, error) {
+	var key rootKey
+	err := mgoCollectionFindId(s.coll, id).One(&key)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return s.getLegacyFromMongo(string(id))
+		}
+		return rootKey{}, errgo.Notef(err, "cannot get key from database")
+	}
+	// TODO migrate the key from the old format to the new format.
+	return key, nil
+}
+
+// getLegacyFromMongo gets a value from the old version of the
+// root key document which used a string key rather than a []byte
+// key.
+func (s *rootKeyStorage) getLegacyFromMongo(id string) (rootKey, error) {
 	var key rootKey
 	err := mgoCollectionFindId(s.coll, id).One(&key)
 	if err != nil {
@@ -241,7 +257,7 @@ func (s *rootKeyStorage) getFromMongo(id string) (rootKey, error) {
 // RootKey implements bakery.RootKeyStorage.RootKey by
 // returning an existing key from the cache when compatible
 // with the current policy.
-func (s *rootKeyStorage) RootKey() ([]byte, string, error) {
+func (s *rootKeyStorage) RootKey() ([]byte, []byte, error) {
 	if key := s.rootKeyFromCache(); key.isValid() {
 		return key.RootKey, key.Id, nil
 	}
@@ -264,18 +280,18 @@ func (s *rootKeyStorage) RootKey() ([]byte, string, error) {
 		},
 	}}).Sort("-created").One(&key)
 	if err != nil && err != mgo.ErrNotFound {
-		return nil, "", errgo.Notef(err, "cannot query existing keys")
+		return nil, nil, errgo.Notef(err, "cannot query existing keys")
 	}
 	if !key.isValid() {
 		// No keys found anywhere, so let's create one.
 		var err error
 		key, err = s.generateKey()
 		if err != nil {
-			return nil, "", errgo.Notef(err, "cannot generate key")
+			return nil, nil, errgo.Notef(err, "cannot generate key")
 		}
 		logger.Infof("new root key id %q", key.Id)
 		if err := s.coll.Insert(key); err != nil {
-			return nil, "", errgo.Notef(err, "cannot create root key")
+			return nil, nil, errgo.Notef(err, "cannot create root key")
 		}
 	}
 	s.keys.mu.Lock()
@@ -323,7 +339,7 @@ func (s *rootKeyStorage) generateKey() (rootKey, error) {
 	return rootKey{
 		Created: now,
 		Expires: now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval),
-		Id:      fmt.Sprintf("%x", newId),
+		Id:      newId,
 		RootKey: newKey,
 	}, nil
 }

--- a/bakery/mgostorage/rootkey_test.go
+++ b/bakery/mgostorage/rootkey_test.go
@@ -1,6 +1,7 @@
 package mgostorage_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/testing"
@@ -8,8 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
 )
 
 type RootKeyStorageSuite struct {
@@ -36,7 +37,7 @@ var isValidWithPolicyTests = []struct {
 	key: mgostorage.RootKey{
 		Created: epoch.Add(19 * time.Minute),
 		Expires: epoch.Add(24 * time.Minute),
-		Id:      "id",
+		Id:      []byte("id"),
 		RootKey: []byte("key"),
 	},
 	expect: true,
@@ -59,7 +60,7 @@ var isValidWithPolicyTests = []struct {
 	key: mgostorage.RootKey{
 		Created: epoch.Add(18*time.Minute - time.Millisecond),
 		Expires: epoch.Add(24 * time.Minute),
-		Id:      "id",
+		Id:      []byte("id"),
 		RootKey: []byte("key"),
 	},
 	expect: false,
@@ -73,7 +74,7 @@ var isValidWithPolicyTests = []struct {
 	key: mgostorage.RootKey{
 		Created: epoch.Add(19 * time.Minute),
 		Expires: epoch.Add(21 * time.Minute),
-		Id:      "id",
+		Id:      []byte("id"),
 		RootKey: []byte("key"),
 	},
 	expect: false,
@@ -87,7 +88,7 @@ var isValidWithPolicyTests = []struct {
 	key: mgostorage.RootKey{
 		Created: epoch.Add(19 * time.Minute),
 		Expires: epoch.Add(25*time.Minute + time.Millisecond),
-		Id:      "id",
+		Id:      []byte("id"),
 		RootKey: []byte("key"),
 	},
 	expect: false,
@@ -130,13 +131,13 @@ func (s *RootKeyStorageSuite) TestRootKeyUsesKeysValidWithPolicy(c *gc.C) {
 		key, id, err := store.RootKey()
 		c.Assert(err, gc.IsNil)
 		if test.expect {
-			c.Assert(id, gc.Equals, "id")
+			c.Assert(string(id), gc.Equals, "id")
 			c.Assert(string(key), gc.Equals, "key")
 		} else {
 			// If it didn't match then RootKey will have
 			// generated a new key.
 			c.Assert(key, gc.HasLen, 24)
-			c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+			c.Assert(id, gc.HasLen, 16)
 		}
 	}
 }
@@ -154,7 +155,7 @@ func (s *RootKeyStorageSuite) TestRootKey(c *gc.C) {
 	key, id, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key, gc.HasLen, 24)
-	c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+	c.Assert(id, gc.HasLen, 16)
 
 	// If we get a key within the generate interval, we should
 	// get the same one.
@@ -162,7 +163,7 @@ func (s *RootKeyStorageSuite) TestRootKey(c *gc.C) {
 	key1, id1, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key1, gc.DeepEquals, key)
-	c.Assert(id1, gc.Equals, id)
+	c.Assert(id1, gc.DeepEquals, id)
 
 	// A different storage instance should get the same root key.
 	store1 := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
@@ -172,22 +173,22 @@ func (s *RootKeyStorageSuite) TestRootKey(c *gc.C) {
 	key1, id1, err = store1.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key1, gc.DeepEquals, key)
-	c.Assert(id1, gc.Equals, id)
+	c.Assert(id1, gc.DeepEquals, id)
 
 	// After the generation interval has passed, we should generate a new key.
 	now = epoch.Add(2*time.Minute + time.Second)
 	key1, id1, err = store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key, gc.HasLen, 24)
-	c.Assert(id, gc.Matches, "[0-9a-f]{32}")
+	c.Assert(id, gc.HasLen, 16)
 	c.Assert(key1, gc.Not(gc.DeepEquals), key)
-	c.Assert(id1, gc.Not(gc.Equals), id)
+	c.Assert(id1, gc.Not(gc.DeepEquals), id)
 
 	// The other store should pick it up too.
 	key2, id2, err := store1.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key2, gc.DeepEquals, key1)
-	c.Assert(id2, gc.Equals, id1)
+	c.Assert(id2, gc.DeepEquals, id1)
 }
 
 func (s *RootKeyStorageSuite) TestRootKeyDefaultGenerateInterval(c *gc.C) {
@@ -205,13 +206,13 @@ func (s *RootKeyStorageSuite) TestRootKeyDefaultGenerateInterval(c *gc.C) {
 	key1, id1, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key1, jc.DeepEquals, key)
-	c.Assert(id1, gc.Equals, id)
+	c.Assert(id1, jc.DeepEquals, id)
 
 	now = epoch.Add(5*time.Minute + time.Millisecond)
 	key1, id1, err = store.RootKey()
 	c.Assert(err, gc.IsNil)
-	c.Assert(key1, gc.Not(gc.DeepEquals), key)
-	c.Assert(id1, gc.Not(gc.Equals), id)
+	c.Assert(string(key1), gc.Not(gc.Equals), string(key))
+	c.Assert(string(id1), gc.Not(gc.Equals), string(id))
 }
 
 var preferredRootKeyTests = []struct {
@@ -219,55 +220,55 @@ var preferredRootKeyTests = []struct {
 	now      time.Time
 	keys     []mgostorage.RootKey
 	policy   mgostorage.Policy
-	expectId string
+	expectId []byte
 }{{
 	about: "latest creation time is preferred",
 	now:   epoch.Add(5 * time.Minute),
 	keys: []mgostorage.RootKey{{
 		Created: epoch.Add(4 * time.Minute),
 		Expires: epoch.Add(15 * time.Minute),
-		Id:      "id0",
+		Id:      []byte("id0"),
 		RootKey: []byte("key0"),
 	}, {
 		Created: epoch.Add(5*time.Minute + 30*time.Second),
 		Expires: epoch.Add(16 * time.Minute),
-		Id:      "id1",
+		Id:      []byte("id1"),
 		RootKey: []byte("key1"),
 	}, {
 		Created: epoch.Add(5 * time.Minute),
 		Expires: epoch.Add(16 * time.Minute),
-		Id:      "id2",
+		Id:      []byte("id2"),
 		RootKey: []byte("key2"),
 	}},
 	policy: mgostorage.Policy{
 		GenerateInterval: 5 * time.Minute,
 		ExpiryDuration:   7 * time.Minute,
 	},
-	expectId: "id1",
+	expectId: []byte("id1"),
 }, {
 	about: "ineligible keys are exluded",
 	now:   epoch.Add(5 * time.Minute),
 	keys: []mgostorage.RootKey{{
 		Created: epoch.Add(4 * time.Minute),
 		Expires: epoch.Add(15 * time.Minute),
-		Id:      "id0",
+		Id:      []byte("id0"),
 		RootKey: []byte("key0"),
 	}, {
 		Created: epoch.Add(5 * time.Minute),
 		Expires: epoch.Add(16*time.Minute + 30*time.Second),
-		Id:      "id1",
+		Id:      []byte("id1"),
 		RootKey: []byte("key1"),
 	}, {
 		Created: epoch.Add(6 * time.Minute),
 		Expires: epoch.Add(time.Hour),
-		Id:      "id2",
+		Id:      []byte("id2"),
 		RootKey: []byte("key2"),
 	}},
 	policy: mgostorage.Policy{
 		GenerateInterval: 5 * time.Minute,
 		ExpiryDuration:   7 * time.Minute,
 	},
-	expectId: "id1",
+	expectId: []byte("id1"),
 }}
 
 func (s *RootKeyStorageSuite) TestPreferredRootKeyFromDatabase(c *gc.C) {
@@ -287,7 +288,7 @@ func (s *RootKeyStorageSuite) TestPreferredRootKeyFromDatabase(c *gc.C) {
 		now = test.now
 		_, id, err := store.RootKey()
 		c.Assert(err, gc.IsNil)
-		c.Assert(id, gc.Equals, test.expectId)
+		c.Assert(id, gc.DeepEquals, test.expectId)
 	}
 }
 
@@ -318,7 +319,7 @@ func (s *RootKeyStorageSuite) TestPreferredRootKeyFromCache(c *gc.C) {
 		now = test.now
 		_, id, err := store.RootKey()
 		c.Assert(err, gc.IsNil)
-		c.Assert(id, gc.Equals, test.expectId)
+		c.Assert(id, jc.DeepEquals, test.expectId)
 	}
 }
 
@@ -341,12 +342,12 @@ func (s *RootKeyStorageSuite) TestGet(c *gc.C) {
 	for i := 0; i < 20; i++ {
 		key, id, err := store.RootKey()
 		c.Assert(err, gc.IsNil)
-		c.Assert(keyIds[id], gc.Equals, false)
-		keys = append(keys, idKey{id, key})
+		c.Assert(keyIds[string(id)], gc.Equals, false)
+		keys = append(keys, idKey{string(id), key})
 		now = now.Add(time.Minute + time.Second)
 	}
 	for i, k := range keys {
-		key, err := store.Get(k.id)
+		key, err := store.Get([]byte(k.id))
 		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
 		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
 	}
@@ -366,14 +367,14 @@ func (s *RootKeyStorageSuite) TestGet(c *gc.C) {
 
 	var fetched []string
 	s.PatchValue(mgostorage.MgoCollectionFindId, func(coll *mgo.Collection, id interface{}) *mgo.Query {
-		fetched = append(fetched, id.(string))
+		fetched = append(fetched, string(id.([]byte)))
 		return coll.FindId(id)
 	})
 	c.Logf("testing cache")
 
 	for i := len(keys) - 1; i >= 0; i-- {
 		k := keys[i]
-		key, err := store.Get(k.id)
+		key, err := store.Get([]byte(k.id))
 		c.Assert(err, gc.IsNil)
 		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
 		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
@@ -391,16 +392,17 @@ func (s *RootKeyStorageSuite) TestGetCachesMisses(c *gc.C) {
 	})
 	var fetched []string
 	s.PatchValue(mgostorage.MgoCollectionFindId, func(coll *mgo.Collection, id interface{}) *mgo.Query {
-		fetched = append(fetched, id.(string))
+		fetched = append(fetched, fmt.Sprintf("%#v", id))
 		return coll.FindId(id)
 	})
-	key, err := store.Get("foo")
+	key, err := store.Get([]byte("foo"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
-	c.Assert(fetched, jc.DeepEquals, []string{"foo"})
+	// This should check twice first using a []byte second using a string
+	c.Assert(fetched, jc.DeepEquals, []string{fmt.Sprintf("%#v", []byte("foo")), fmt.Sprintf("%#v", "foo")})
 	fetched = nil
 
-	key, err = store.Get("foo")
+	key, err = store.Get([]byte("foo"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 	c.Assert(fetched, gc.IsNil)
@@ -468,6 +470,29 @@ func (s *RootKeyStorageSuite) TestEnsureIndex(c *gc.C) {
 		}
 	}
 	c.Fatalf("key was never removed from database")
+}
+
+type legacyRootKey struct {
+	Id      string `bson:"_id"`
+	Created time.Time
+	Expires time.Time
+	RootKey []byte
+}
+
+func (s *RootKeyStorageSuite) TestLegacy(c *gc.C) {
+	err := s.coll().Insert(&legacyRootKey{
+		Id:      "foo",
+		RootKey: []byte("a key"),
+		Created: time.Now(),
+		Expires: time.Now().Add(10 * time.Minute),
+	})
+	c.Assert(err, gc.IsNil)
+	store := mgostorage.NewRootKeys(10).NewStorage(s.coll(), mgostorage.Policy{
+		ExpiryDuration: 5 * time.Minute,
+	})
+	rk, err := store.Get([]byte("foo"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(rk), gc.Equals, "a key")
 }
 
 func (s *RootKeyStorageSuite) coll() *mgo.Collection {

--- a/bakery/mgostorage/storage.go
+++ b/bakery/mgostorage/storage.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 // New returns an implementation of Storage

--- a/bakery/mgostorage/storage_test.go
+++ b/bakery/mgostorage/storage_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
 )
 
 type StorageSuite struct {
@@ -108,7 +108,7 @@ func (s *StorageSuite) TestCreateMacaroon(c *gc.C) {
 	c.Assert(service, gc.NotNil)
 
 	m, err := service.NewMacaroon(
-		"123",
+		[]byte("123"),
 		[]byte("abc"),
 		[]checkers.Caveat{checkers.Caveat{Location: "", Condition: "is-authorised bob"}},
 	)

--- a/bakery/storage_test.go
+++ b/bakery/storage_test.go
@@ -6,7 +6,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 type StorageSuite struct{}
@@ -64,28 +64,28 @@ func (*StorageSuite) TestConcurrentMemStorage(c *gc.C) {
 
 func (*StorageSuite) TestMemRootKeyStorage(c *gc.C) {
 	store := bakery.NewMemRootKeyStorage()
-	key, err := store.Get("x")
+	key, err := store.Get([]byte("x"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 
-	key, err = store.Get("0")
+	key, err = store.Get([]byte("0"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 
 	key, id, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key, gc.HasLen, 24)
-	c.Assert(id, gc.Equals, "0")
+	c.Assert(string(id), gc.Equals, "0")
 
 	key1, id1, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key1, jc.DeepEquals, key)
-	c.Assert(id1, gc.Equals, id)
+	c.Assert(id1, gc.DeepEquals, id)
 
 	key2, err := store.Get(id)
 	c.Assert(err, gc.IsNil)
 	c.Assert(key2, jc.DeepEquals, key)
 
-	_, err = store.Get("1")
+	_, err = store.Get([]byte("1"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 }

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/juju/httprequest"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type suite struct {
@@ -39,7 +39,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -83,7 +83,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 		Locator:  locator,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d2.Location(),
 		Condition: "true",
 	}})
@@ -156,7 +156,7 @@ func (s *suite) TestInteractiveDischarger(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -191,7 +191,7 @@ func (s *suite) TestLoginDischargerError(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -224,7 +224,7 @@ func (s *suite) TestInteractiveDischargerURL(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})

--- a/cmd/bakery-keygen/main.go
+++ b/cmd/bakery-keygen/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 func main() {

--- a/httpbakery/agent/agent.go
+++ b/httpbakery/agent/agent.go
@@ -19,8 +19,8 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var logger = loggo.GetLogger("httpbakery.agent")

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -9,10 +9,10 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/agent"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
 )
 
 type agentSuite struct {
@@ -97,7 +97,7 @@ func (s *agentSuite) TestAgentLogin(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		err = agent.SetUpAuth(client, u, "test-user")
 		c.Assert(err, gc.IsNil)
-		m, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := s.bakery.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  s.discharger.URL,
 			Condition: "test condition",
 		}})
@@ -126,7 +126,7 @@ func (s *agentSuite) TestSetUpAuthError(c *gc.C) {
 func (s *agentSuite) TestNoCookieError(c *gc.C) {
 	client := httpbakery.NewClient()
 	client.VisitWebPage = agent.VisitWebPage(client)
-	m, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := s.bakery.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  s.discharger.URL,
 		Condition: "test condition",
 	}})

--- a/httpbakery/agent/discharge_test.go
+++ b/httpbakery/agent/discharge_test.go
@@ -10,16 +10,16 @@ import (
 	"sync"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/agent"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
 )
 
 type discharge struct {
-	cavId string
+	cavId []byte
 	c     chan error
 }
 
@@ -89,10 +89,10 @@ func (d *Discharger) FinishWait(w http.ResponseWriter, r *http.Request, err erro
 	return
 }
 
-func (d *Discharger) checker(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+func (d *Discharger) checker(req *http.Request, ci *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	d.mu.Lock()
 	id := len(d.waiting)
-	d.waiting = append(d.waiting, discharge{cavId, make(chan error, 1)})
+	d.waiting = append(d.waiting, discharge{ci.MacaroonId, make(chan error, 1)})
 	d.mu.Unlock()
 	return nil, &httpbakery.Error{
 		Code:    httpbakery.ErrInteractionRequired,
@@ -125,7 +125,7 @@ func (d *Discharger) login(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	m, err := d.Bakery.NewMacaroon("", nil, []checkers.Caveat{
+	m, err := d.Bakery.NewMacaroon(nil, nil, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(al.PublicKey),
 	})
 	if err != nil {
@@ -153,7 +153,7 @@ func (d *Discharger) wait(w http.ResponseWriter, r *http.Request) {
 	}
 	m, err := d.Bakery.Discharge(
 		bakery.ThirdPartyCheckerFunc(
-			func(cavId, caveat string) ([]checkers.Caveat, error) {
+			func(*bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 				return nil, nil
 			},
 		),

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type httpContext struct {

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -7,8 +7,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type CheckersSuite struct{}

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -9,15 +9,15 @@ import (
 	"github.com/juju/httprequest"
 	"github.com/julienschmidt/httprouter"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type dischargeHandler struct {
 	svc     *bakery.Service
-	checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error)
+	checker func(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
 }
 
 // AddDischargeHandler adds handlers to the given
@@ -44,9 +44,9 @@ type dischargeHandler struct {
 //
 // POST /discharge
 //	params:
-//		id: id of macaroon to discharge
-//		location: location of original macaroon (optional (?))
-//		?? flow=redirect|newwindow
+//		id: all-UTF-8 third party caveat id
+//		id64: non-padded URL-base64 encoded caveat id
+//		macaroon-id: (optional) id to give to discharge macaroon (defaults to id)
 //	result on success (http.StatusOK):
 //		{
 //			Macaroon *macaroon.Macaroon
@@ -56,7 +56,7 @@ type dischargeHandler struct {
 //	result:
 //		public key of service
 //		expiry time of key
-func AddDischargeHandler(mux *http.ServeMux, rootPath string, svc *bakery.Service, checker func(req *http.Request, cavId, cav string) ([]checkers.Caveat, error)) {
+func AddDischargeHandler(mux *http.ServeMux, rootPath string, svc *bakery.Service, checker func(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)) {
 	d := &dischargeHandler{
 		svc:     svc,
 		checker: checker,
@@ -93,15 +93,17 @@ func (d *dischargeHandler) serveDischarge1(p httprequest.Params) (interface{}, e
 	if id == "" {
 		return nil, badRequestErrorf("id attribute is empty")
 	}
-	checker := func(cavId, cav string) ([]checkers.Caveat, error) {
-		return d.checker(p.Request, cavId, cav)
+	// TODO support macaroon id independent of caveat id
+
+	checker := func(info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+		return d.checker(p.Request, info)
 	}
 
 	// TODO(rog) pass location into discharge
 	// location := p.Request.Form.Get("location")
 
 	var resp dischargeResponse
-	m, err := d.svc.Discharge(bakery.ThirdPartyCheckerFunc(checker), id)
+	m, err := d.svc.Discharge(bakery.ThirdPartyCheckerFunc(checker), []byte(id))
 	if err != nil {
 		return nil, errgo.NoteMask(err, "cannot discharge", errgo.Any)
 	}

--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 // ErrorCode holds an error code that classifies

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -10,9 +10,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type ErrorSuite struct{}
@@ -20,7 +20,7 @@ type ErrorSuite struct{}
 var _ = gc.Suite(&ErrorSuite{})
 
 func (s *ErrorSuite) TestWriteDischargeRequiredError(c *gc.C) {
-	m, err := macaroon.New([]byte("secret"), "id", "a location")
+	m, err := macaroon.New([]byte("secret"), []byte("id"), "a location")
 	c.Assert(err, gc.IsNil)
 	tests := []struct {
 		about            string

--- a/httpbakery/form/form.go
+++ b/httpbakery/form/form.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var logger = loggo.GetLogger("httpbakery.form")

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -12,11 +12,11 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	esform "gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/form"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
 )
 
 type formSuite struct {
@@ -142,7 +142,7 @@ func (s *formSuite) TestFormLogin(c *gc.C) {
 	for i, test := range formLoginTests {
 		c.Logf("test %d: %s", i, test.about)
 		d.dischargeOptions = test.opts
-		m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  d.discharger.Location(),
 			Condition: "test condition",
 		}})
@@ -200,7 +200,7 @@ func (s *formSuite) TestFormTitle(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for i, test := range formTitleTests {
 		c.Logf("test %d: %s", i, test.host)
-		m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  "https://" + test.host,
 			Condition: "test condition",
 		}})

--- a/httpbakery/keyring.go
+++ b/httpbakery/keyring.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 // NewPublicKeyRing returns a new public keyring that uses

--- a/httpbakery/keyring_test.go
+++ b/httpbakery/keyring_test.go
@@ -11,9 +11,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type KeyringSuite struct {

--- a/httpbakery/visitor_test.go
+++ b/httpbakery/visitor_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type VisitorSuite struct {


### PR DESCRIPTION
We use the macaroon.v2-unstable package, allowing us to
have binary caveat ids and macaroon ids.

We change some of the API accordingly, removing some elements
that are unnecessary, such as the first party location argument
to the Discharge method.
