### PR TITLE
all: new v2-unstable version

### DIFF
--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -8,10 +8,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type CheckersSuite struct{}
@@ -415,13 +415,13 @@ func (*CheckersSuite) TestInferDeclared(c *gc.C) {
 		c.Logf("test %d: %s", i, test.about)
 		ms := make(macaroon.Slice, len(test.caveats))
 		for i, caveats := range test.caveats {
-			m, err := macaroon.New(nil, fmt.Sprint(i), "")
+			m, err := macaroon.New(nil, []byte(fmt.Sprint(i)), "")
 			c.Assert(err, gc.IsNil)
 			for _, cav := range caveats {
 				if cav.Location == "" {
 					m.AddFirstPartyCaveat(cav.Condition)
 				} else {
-					m.AddThirdPartyCaveat(nil, cav.Condition, cav.Location)
+					m.AddThirdPartyCaveat(nil, []byte(cav.Condition), cav.Location)
 				}
 			}
 			ms[i] = m

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 // DeclaredCaveat returns a "declared" caveat asserting that the given key is
@@ -84,7 +84,7 @@ func InferDeclared(ms macaroon.Slice) Declared {
 			if cav.Location != "" {
 				continue
 			}
-			name, rest, err := ParseCaveat(cav.Id)
+			name, rest, err := ParseCaveat(string(cav.Id))
 			if err != nil {
 				continue
 			}

--- a/bakery/checkers/time.go
+++ b/bakery/checkers/time.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 var timeNow = time.Now
@@ -39,10 +39,11 @@ func ExpiryTime(cavs []macaroon.Caveat) (time.Time, bool) {
 	var t time.Time
 	var expires bool
 	for _, cav := range cavs {
-		if !strings.HasPrefix(cav.Id, CondTimeBefore) {
+		cond := string(cav.Id)
+		if !strings.HasPrefix(cond, CondTimeBefore) {
 			continue
 		}
-		et, err := time.Parse(CondTimeBefore+" "+time.RFC3339Nano, cav.Id)
+		et, err := time.Parse(CondTimeBefore+" "+time.RFC3339Nano, cond)
 		if err != nil {
 			continue
 		}

--- a/bakery/checkers/time_test.go
+++ b/bakery/checkers/time_test.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type timeSuite struct{}
@@ -31,7 +31,7 @@ var expireTimeTests = []struct {
 	about: "single time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 	},
 	expectTime:    t1,
@@ -40,17 +40,17 @@ var expireTimeTests = []struct {
 	about: "single deny caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.DenyCaveat("abc").Condition,
+			Id: []byte(checkers.DenyCaveat("abc").Condition),
 		},
 	},
 }, {
 	about: "multiple time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t2).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t2).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 	},
 	expectTime:    t1,
@@ -59,16 +59,16 @@ var expireTimeTests = []struct {
 	about: "mixed caveats",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t1).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t1).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.AllowCaveat("abc").Condition,
+			Id: []byte(checkers.AllowCaveat("abc").Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.TimeBeforeCaveat(t2).Condition,
+			Id: []byte(checkers.TimeBeforeCaveat(t2).Condition),
 		},
 		macaroon.Caveat{
-			Id: checkers.DenyCaveat("def").Condition,
+			Id: []byte(checkers.DenyCaveat("def").Condition),
 		},
 	},
 	expectTime:    t1,
@@ -77,7 +77,7 @@ var expireTimeTests = []struct {
 	about: "invalid time-before caveat",
 	caveats: []macaroon.Caveat{
 		macaroon.Caveat{
-			Id: checkers.CondTimeBefore + " tomorrow",
+			Id: []byte(checkers.CondTimeBefore + " tomorrow"),
 		},
 	},
 }}
@@ -157,7 +157,7 @@ func (s *timeSuite) TestMacaroonsExpireTime(c *gc.C) {
 }
 
 func mustNewMacaroon(cavs ...string) *macaroon.Macaroon {
-	m, err := macaroon.New(nil, "", "")
+	m, err := macaroon.New(nil, nil, "")
 	if err != nil {
 		panic(err)
 	}

--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // authService implements an authorization service,
@@ -31,8 +31,8 @@ func authService(endpoint string, key *bakery.KeyPair) (http.Handler, error) {
 //
 // Note how this function can return additional first- and third-party
 // caveats which will be added to the original macaroon's caveats.
-func thirdPartyChecker(req *http.Request, cavId, condition string) ([]checkers.Caveat, error) {
-	if condition != "access-allowed" {
+func thirdPartyChecker(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+	if cav.Condition != "access-allowed" {
 		return nil, checkers.ErrCaveatNotRecognized
 	}
 	// TODO check that the HTTP request has cookies that prove

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // client represents a client of the target service.

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 func TestPackage(t *testing.T) {

--- a/bakery/example/idservice/idservice_test.go
+++ b/bakery/example/idservice/idservice_test.go
@@ -13,9 +13,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/example/idservice"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/idservice"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type suite struct {

--- a/bakery/example/idservice/meeting.go
+++ b/bakery/example/idservice/meeting.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/meeting"
 )
 
 type thirdPartyCaveatInfo struct {
-	CaveatId string
+	CaveatId []byte
 	Caveat   string
 }
 

--- a/bakery/example/idservice/targetservice_test.go
+++ b/bakery/example/idservice/targetservice_test.go
@@ -7,9 +7,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type targetServiceHandler struct {
@@ -108,7 +108,7 @@ func (srv *targetServiceHandler) writeError(w http.ResponseWriter, req *http.Req
 		Condition: "operation " + operation,
 	}}
 	// Mint an appropriate macaroon and send it back to the client.
-	m, err := srv.svc.NewMacaroon("", nil, caveats)
+	m, err := srv.svc.NewMacaroon(nil, nil, caveats)
 	if err != nil {
 		fail(http.StatusInternalServerError, "cannot mint macaroon: %v", err)
 		return

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -24,8 +24,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var defaultHTTPClient = httpbakery.NewHTTPClient()

--- a/bakery/example/meeting/meeting_test.go
+++ b/bakery/example/meeting/meeting_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/example/meeting"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/example/meeting"
 )
 
 type suite struct{}

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -8,9 +8,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type targetServiceHandler struct {
@@ -113,7 +113,7 @@ func (srv *targetServiceHandler) writeError(w http.ResponseWriter, req *http.Req
 			Condition: "operation " + operation,
 		}}
 	// Mint an appropriate macaroon and send it back to the client.
-	m, err := srv.svc.NewMacaroon("", nil, caveats)
+	m, err := srv.svc.NewMacaroon(nil, nil, caveats)
 	if err != nil {
 		fail(http.StatusInternalServerError, "cannot mint macaroon: %v", err)
 		return

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 type KeysSuite struct{}

--- a/bakery/mgostorage/storage.go
+++ b/bakery/mgostorage/storage.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 // New returns an implementation of Storage

--- a/bakery/mgostorage/storage_test.go
+++ b/bakery/mgostorage/storage_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
 )
 
 type StorageSuite struct {
@@ -108,7 +108,7 @@ func (s *StorageSuite) TestCreateMacaroon(c *gc.C) {
 	c.Assert(service, gc.NotNil)
 
 	m, err := service.NewMacaroon(
-		"123",
+		[]byte("123"),
 		[]byte("abc"),
 		[]checkers.Caveat{checkers.Caveat{Location: "", Condition: "is-authorised bob"}},
 	)

--- a/bakery/storage_test.go
+++ b/bakery/storage_test.go
@@ -6,7 +6,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 type StorageSuite struct{}
@@ -64,28 +64,28 @@ func (*StorageSuite) TestConcurrentMemStorage(c *gc.C) {
 
 func (*StorageSuite) TestMemRootKeyStorage(c *gc.C) {
 	store := bakery.NewMemRootKeyStorage()
-	key, err := store.Get("x")
+	key, err := store.Get([]byte("x"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 
-	key, err = store.Get("0")
+	key, err = store.Get([]byte("0"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 
 	key, id, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key, gc.HasLen, 24)
-	c.Assert(id, gc.Equals, "0")
+	c.Assert(string(id), gc.Equals, "0")
 
 	key1, id1, err := store.RootKey()
 	c.Assert(err, gc.IsNil)
 	c.Assert(key1, jc.DeepEquals, key)
-	c.Assert(id1, gc.Equals, id)
+	c.Assert(id1, gc.DeepEquals, id)
 
 	key2, err := store.Get(id)
 	c.Assert(err, gc.IsNil)
 	c.Assert(key2, jc.DeepEquals, key)
 
-	_, err = store.Get("1")
+	_, err = store.Get([]byte("1"))
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 }

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/juju/httprequest"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type suite struct {
@@ -39,7 +39,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -83,7 +83,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 		Locator:  locator,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d2.Location(),
 		Condition: "true",
 	}})
@@ -156,7 +156,7 @@ func (s *suite) TestInteractiveDischarger(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -191,7 +191,7 @@ func (s *suite) TestLoginDischargerError(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})
@@ -224,7 +224,7 @@ func (s *suite) TestInteractiveDischargerURL(c *gc.C) {
 		Locator:  d,
 	})
 	c.Assert(err, gc.IsNil)
-	m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}})

--- a/cmd/bakery-keygen/main.go
+++ b/cmd/bakery-keygen/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 func main() {

--- a/httpbakery/agent/agent.go
+++ b/httpbakery/agent/agent.go
@@ -19,8 +19,8 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var logger = loggo.GetLogger("httpbakery.agent")

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -9,10 +9,10 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/agent"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
 )
 
 type agentSuite struct {
@@ -97,7 +97,7 @@ func (s *agentSuite) TestAgentLogin(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		err = agent.SetUpAuth(client, u, "test-user")
 		c.Assert(err, gc.IsNil)
-		m, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := s.bakery.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  s.discharger.URL,
 			Condition: "test condition",
 		}})
@@ -126,7 +126,7 @@ func (s *agentSuite) TestSetUpAuthError(c *gc.C) {
 func (s *agentSuite) TestNoCookieError(c *gc.C) {
 	client := httpbakery.NewClient()
 	client.VisitWebPage = agent.VisitWebPage(client)
-	m, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{{
+	m, err := s.bakery.NewMacaroon(nil, nil, []checkers.Caveat{{
 		Location:  s.discharger.URL,
 		Condition: "test condition",
 	}})

--- a/httpbakery/agent/discharge_test.go
+++ b/httpbakery/agent/discharge_test.go
@@ -10,16 +10,16 @@ import (
 	"sync"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/agent"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
 )
 
 type discharge struct {
-	cavId string
+	cavId []byte
 	c     chan error
 }
 
@@ -89,10 +89,10 @@ func (d *Discharger) FinishWait(w http.ResponseWriter, r *http.Request, err erro
 	return
 }
 
-func (d *Discharger) checker(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+func (d *Discharger) checker(req *http.Request, ci *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	d.mu.Lock()
 	id := len(d.waiting)
-	d.waiting = append(d.waiting, discharge{cavId, make(chan error, 1)})
+	d.waiting = append(d.waiting, discharge{ci.MacaroonId, make(chan error, 1)})
 	d.mu.Unlock()
 	return nil, &httpbakery.Error{
 		Code:    httpbakery.ErrInteractionRequired,
@@ -125,7 +125,7 @@ func (d *Discharger) login(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	m, err := d.Bakery.NewMacaroon("", nil, []checkers.Caveat{
+	m, err := d.Bakery.NewMacaroon(nil, nil, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(al.PublicKey),
 	})
 	if err != nil {
@@ -153,7 +153,7 @@ func (d *Discharger) wait(w http.ResponseWriter, r *http.Request) {
 	}
 	m, err := d.Bakery.Discharge(
 		bakery.ThirdPartyCheckerFunc(
-			func(cavId, caveat string) ([]checkers.Caveat, error) {
+			func(*bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 				return nil, nil
 			},
 		),

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 type httpContext struct {

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -7,8 +7,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type CheckersSuite struct{}

--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 // ErrorCode holds an error code that classifies

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -10,9 +10,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type ErrorSuite struct{}
@@ -20,7 +20,7 @@ type ErrorSuite struct{}
 var _ = gc.Suite(&ErrorSuite{})
 
 func (s *ErrorSuite) TestWriteDischargeRequiredError(c *gc.C) {
-	m, err := macaroon.New([]byte("secret"), "id", "a location")
+	m, err := macaroon.New([]byte("secret"), []byte("id"), "a location")
 	c.Assert(err, gc.IsNil)
 	tests := []struct {
 		about            string

--- a/httpbakery/form/form.go
+++ b/httpbakery/form/form.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 var logger = loggo.GetLogger("httpbakery.form")

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -12,11 +12,11 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	esform "gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery/form"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
 )
 
 type formSuite struct {
@@ -142,7 +142,7 @@ func (s *formSuite) TestFormLogin(c *gc.C) {
 	for i, test := range formLoginTests {
 		c.Logf("test %d: %s", i, test.about)
 		d.dischargeOptions = test.opts
-		m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  d.discharger.Location(),
 			Condition: "test condition",
 		}})
@@ -200,7 +200,7 @@ func (s *formSuite) TestFormTitle(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for i, test := range formTitleTests {
 		c.Logf("test %d: %s", i, test.host)
-		m, err := svc.NewMacaroon("", nil, []checkers.Caveat{{
+		m, err := svc.NewMacaroon(nil, nil, []checkers.Caveat{{
 			Location:  "https://" + test.host,
 			Condition: "test condition",
 		}})

--- a/httpbakery/keyring.go
+++ b/httpbakery/keyring.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
 
 // NewPublicKeyRing returns a new public keyring that uses

--- a/httpbakery/keyring_test.go
+++ b/httpbakery/keyring_test.go
@@ -11,9 +11,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type KeyringSuite struct {

--- a/httpbakery/visitor_test.go
+++ b/httpbakery/visitor_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 type VisitorSuite struct {


### PR DESCRIPTION
We use the macaroon.v2-unstable package, allowing us to
have binary caveat ids and macaroon ids.

We change some of the API accordingly, removing some elements
that are unnecessary, such as the first party location argument
to the AcquireDischarge method.

Note that this changes the format of root keys stored by the mgostorage
package. There is some code to partially deal with that by falling back
to fetching from the old format, but a subsequent PR will make that more
comprehensive.

This also adds the ability for a third party discharger to be able to
see the keys used to decrypt the third party caveat, which will
enable some proposed use cases.
