### PR TITLE
httpbakery: more reusable discharger handlers

### DIFF
--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -20,8 +20,9 @@ func authService(endpoint string, key *bakery.KeyPair) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	d := httpbakery.NewDischargerFromService(svc, httpbakery.ThirdPartyCaveatCheckerFunc(thirdPartyChecker))
 	mux := http.NewServeMux()
-	httpbakery.AddDischargeHandler(mux, "/", svc, thirdPartyChecker)
+	d.AddMuxHandlers(mux, "/")
 	return mux, nil
 }
 

--- a/bakery/example/idservice/idservice.go
+++ b/bakery/example/idservice/idservice.go
@@ -59,7 +59,8 @@ func New(p Params) (http.Handler, error) {
 		place: &place{meeting.New()},
 	}
 	mux := http.NewServeMux()
-	httpbakery.AddDischargeHandler(mux, "/", svc, h.checkThirdPartyCaveat)
+	d := httpbakery.NewDischargerFromService(svc, h)
+	d.AddMuxHandlers(mux, "/")
 	mux.Handle("/user/", mkHandler(handleJSON(h.userHandler)))
 	mux.HandleFunc("/login", h.loginHandler)
 	mux.Handle("/question", mkHandler(handleJSON(h.questionHandler)))
@@ -193,8 +194,8 @@ func (h *handler) loginAttemptHandler(w http.ResponseWriter, req *http.Request) 
 	})
 }
 
-// checkThirdPartyCaveat is called by the httpbakery discharge handler.
-func (h *handler) checkThirdPartyCaveat(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+// CheckThirdPartyCaveat is called by the httpbakery discharge handler.
+func (h *handler) CheckThirdPartyCaveat(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	return h.newContext(req, "").CheckThirdPartyCaveat(cav)
 }
 

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -104,7 +104,8 @@ func NewDischarger(
 		}
 		return checker(req, cond, arg)
 	}
-	httpbakery.AddDischargeHandler(mux, "/", svc, checker1)
+	d := httpbakery.NewDischargerFromService(svc, httpbakery.ThirdPartyCaveatCheckerFunc(checker1))
+	d.AddMuxHandlers(mux, "/")
 	startSkipVerify()
 	return &Discharger{
 		Service: svc,
@@ -212,7 +213,8 @@ func NewInteractiveDischarger(locator bakery.PublicKeyLocator, visitHandler http
 	if err != nil {
 		panic(err)
 	}
-	httpbakery.AddDischargeHandler(d.Mux, "/", svc, d.checker)
+	bd := httpbakery.NewDischargerFromService(svc, d)
+	bd.AddMuxHandlers(d.Mux, "/")
 	startSkipVerify()
 	d.Discharger = Discharger{
 		Service: svc,
@@ -221,7 +223,9 @@ func NewInteractiveDischarger(locator bakery.PublicKeyLocator, visitHandler http
 	return d
 }
 
-func (d *InteractiveDischarger) checker(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+// CheckThirdPartyCaveat implements httpbakery.ThirdPartyCaveatDischarger
+// by always returning an interaction-required error.
+func (d *InteractiveDischarger) CheckThirdPartyCaveat(req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	d.mu.Lock()
 	id := fmt.Sprintf("%d", d.id)
 	d.id++

--- a/httpbakery/agent/discharge_test.go
+++ b/httpbakery/agent/discharge_test.go
@@ -34,7 +34,8 @@ type Discharger struct {
 
 func (d *Discharger) ServeMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	httpbakery.AddDischargeHandler(mux, "/", d.Bakery, d.checker)
+	discharger := httpbakery.NewDischargerFromService(d.Bakery, d)
+	discharger.AddMuxHandlers(mux, "/")
 	mux.Handle("/login", http.HandlerFunc(d.login))
 	mux.Handle("/wait", http.HandlerFunc(d.wait))
 	mux.Handle("/", http.HandlerFunc(d.notfound))
@@ -89,7 +90,7 @@ func (d *Discharger) FinishWait(w http.ResponseWriter, r *http.Request, err erro
 	return
 }
 
-func (d *Discharger) checker(req *http.Request, ci *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+func (d *Discharger) CheckThirdPartyCaveat(req *http.Request, ci *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	d.mu.Lock()
 	id := len(d.waiting)
 	d.waiting = append(d.waiting, discharge{ci.MacaroonId, make(chan error, 1)})

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -464,8 +464,6 @@ func SetCookie(jar http.CookieJar, url *url.URL, ms macaroon.Slice) error {
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	// TODO verify that setting this for the URL makes it available
-	// to all paths under that URL.
 	jar.SetCookies(url, []*http.Cookie{cookie})
 	return nil
 }
@@ -488,7 +486,7 @@ func appendURLElem(u, elem string) string {
 func (c *Client) AcquireDischarge(cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 	var resp dischargeResponse
 	loc := appendURLElem(cav.Location, "discharge")
-	// TODO support base64 encoding of binary caveat ids.
+	// TODO use id64 field for encoding caveat id when it's  not valid UTF-8.
 	err := postFormJSON(
 		loc,
 		url.Values{

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -15,26 +15,54 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
-type dischargeHandler struct {
-	svc     *bakery.Service
-	checker func(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
+// ThirdPartyCaveatChecker is used to check third party caveats.
+type ThirdPartyCaveatChecker interface {
+	// CheckThirdPartyCaveat is used to check whether a client
+	// making the given request should be allowed a discharge for
+	// the given caveat. On success, the caveat will be discharged,
+	// with any returned caveats also added to the discharge
+	// macaroon.
+	//
+	// Note than when used in the context of a discharge handler
+	// created by Discharger, any returned errors will be marshaled
+	// as documented in DischargeHandler.ErrorMapper.
+	CheckThirdPartyCaveat(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
 }
 
-// AddDischargeHandler adds handlers to the given
-// ServeMux to serve third party caveat discharges
-// using the given service.
+// ThirdPartyCaveatCheckerFunc implements ThirdPartyCaveatChecker
+// by calling a function.
+type ThirdPartyCaveatCheckerFunc func(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
+
+func (f ThirdPartyCaveatCheckerFunc) CheckThirdPartyCaveat(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+	return f(req, info)
+}
+
+// Discharger holds parameters for creating a new Discharger.
+type DischargerParams struct {
+	// Checker is used to actually check the caveats.
+	Checker ThirdPartyCaveatChecker
+
+	// Key holds the key pair of the discharger.
+	Key *bakery.KeyPair
+
+	// Locator is used to find public keys when adding
+	// third-party caveats on discharge macaroons.
+	// If this is nil, no third party caveats may be added.
+	Locator bakery.PublicKeyLocator
+
+	// ErrorToResponse is used to convert errors returned by the third
+	// party caveat checker to the form that will be JSON-marshaled
+	// on the wire. If zero, this defaults to ErrorToResponse.
+	// If set, it should handle errors that it does not understand
+	// by falling back to calling ErrorToResponse to ensure
+	// that the standard bakery errors are marshaled in the expected way.
+	ErrorToResponse func(err error) (int, interface{})
+}
+
+// Discharger represents a third-party caveat discharger.
+// can discharge caveats in an HTTP server.
 //
-// The handlers are added under the given rootPath,
-// which must be non-empty.
-//
-// The check function is used to check whether a client making the given
-// request should be allowed a discharge for the given caveat. If it
-// does not return an error, the caveat will be discharged, with any
-// returned caveats also added to the discharge macaroon.
-// If it returns an error with a *Error cause, the error will be marshaled
-// and sent back to the client.
-//
-// The name space served by DischargeHandler is as follows.
+// The name space served by dischargers is as follows.
 // All parameters can be provided either as URL attributes
 // or form attributes. The result is always formatted as a JSON
 // object.
@@ -56,66 +84,122 @@ type dischargeHandler struct {
 //	result:
 //		public key of service
 //		expiry time of key
-func AddDischargeHandler(mux *http.ServeMux, rootPath string, svc *bakery.Service, checker func(req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)) {
-	d := &dischargeHandler{
-		svc:     svc,
-		checker: checker,
-	}
-	mux.Handle(path.Join(rootPath, "discharge"), mkHandler(handleJSON(d.serveDischarge)))
-	// TODO(rog) is there a case for making public key caveat signing
-	// optional?
-	mux.Handle(path.Join(rootPath, "publickey"), mkHandler(handleJSON(d.servePublicKey)))
+type Discharger struct {
+	p DischargerParams
 }
 
+// NewDischargerFromService returns a new third-party caveat
+// discharger using the key and locator from the given service.
+func NewDischargerFromService(svc *bakery.Service, checker ThirdPartyCaveatChecker) *Discharger {
+	return NewDischarger(DischargerParams{
+		Checker: checker,
+		Key:     svc.Key(),
+		Locator: svc.Locator(),
+	})
+}
+
+// NewDischarger returns a new third-party caveat discharger
+// using the given parameters.
+func NewDischarger(p DischargerParams) *Discharger {
+	if p.ErrorToResponse == nil {
+		p.ErrorToResponse = ErrorToResponse
+	}
+	if p.Locator == nil {
+		p.Locator = bakery.PublicKeyLocatorMap(nil)
+	}
+	return &Discharger{
+		p: p,
+	}
+}
+
+// AddMuxHandlers adds handlers to the given ServeMux to provide
+// a third-party caveat discharge service.
+func (d *Discharger) AddMuxHandlers(mux *http.ServeMux, rootPath string) {
+	for _, h := range d.Handlers() {
+		// Note: this only works because we don't have any wildcard
+		// patterns in the discharger paths.
+		mux.Handle(path.Join(rootPath, h.Path), mkHTTPHandler(h.Handle))
+	}
+}
+
+// Handlers returns a slice of handlers that can handle a third-party
+// caveat discharge service when added to an httprouter.Router.
+func (d *Discharger) Handlers() []httprequest.Handler {
+	f := func(p httprequest.Params) (dischargeHandler, error) {
+		return dischargeHandler{
+			discharger: d,
+		}, nil
+	}
+	return httprequest.ErrorMapper(d.p.ErrorToResponse).Handlers(f)
+}
+
+// dischargeHandler is the type used to define the httprequest handler
+// methods for a discharger.
+type dischargeHandler struct {
+	discharger *Discharger
+}
+
+// dischargeRequest is a request to create a macaroon that discharges the
+// supplied third-party caveat. Discharging caveats will normally be
+// handled by the bakery it would be unusual to use this type directly in
+// client software.
+type dischargeRequest struct {
+	httprequest.Route `httprequest:"POST /discharge"`
+	Id                string `httprequest:"id,form"`
+	//	Id64		string `httprequest:"id64,form"`
+	// MacaroonId string `httprequest:"macaroon-id,form"`
+}
+
+// dischargeResponse contains the response from a /discharge POST request.
 type dischargeResponse struct {
 	Macaroon *macaroon.Macaroon `json:",omitempty"`
 }
 
-func (d *dischargeHandler) serveDischarge(p httprequest.Params) (interface{}, error) {
-	r, err := d.serveDischarge1(p)
-	if err != nil {
-		logger.Debugf("serveDischarge -> error %#v", err)
-	} else {
-		logger.Debugf("serveDischarge -> %#v", r)
+// Discharge discharges a third party caveat.
+func (h dischargeHandler) Discharge(p httprequest.Params, r *dischargeRequest) (*dischargeResponse, error) {
+	m, caveats, err := bakery.Discharge(h.discharger.p.Key, bakery.ThirdPartyCheckerFunc(
+		func(cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+			return h.discharger.p.Checker.CheckThirdPartyCaveat(p.Request, cav)
+		},
+	), []byte(r.Id))
+	for _, cav := range caveats {
+		if err := bakery.AddCaveat(h.discharger.p.Key, h.discharger.p.Locator, m, cav); err != nil {
+			return nil, errgo.Mask(err)
+		}
 	}
-	return r, err
-}
-
-func (d *dischargeHandler) serveDischarge1(p httprequest.Params) (interface{}, error) {
-	logger.Debugf("dischargeHandler.serveDischarge {")
-	defer logger.Debugf("}")
-	if p.Request.Method != "POST" {
-		// TODO http.StatusMethodNotAllowed)
-		return nil, badRequestErrorf("method not allowed")
-	}
-	p.Request.ParseForm()
-	id := p.Request.Form.Get("id")
-	if id == "" {
-		return nil, badRequestErrorf("id attribute is empty")
-	}
-	// TODO support macaroon id independent of caveat id
-
-	checker := func(info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-		return d.checker(p.Request, info)
-	}
-
-	var resp dischargeResponse
-	m, err := d.svc.Discharge(bakery.ThirdPartyCheckerFunc(checker), []byte(id))
 	if err != nil {
 		return nil, errgo.NoteMask(err, "cannot discharge", errgo.Any)
 	}
-	resp.Macaroon = m
-	return &resp, nil
+	return &dischargeResponse{m}, nil
 }
 
+// publicKeyRequest specifies the /publickey endpoint.
+type publicKeyRequest struct {
+	httprequest.Route `httprequest:"GET /publickey"`
+}
+
+// publicKeyResponse is the response to a /publickey GET request.
 type publicKeyResponse struct {
 	PublicKey *bakery.PublicKey
 }
 
-func (d *dischargeHandler) servePublicKey(httprequest.Params) (interface{}, error) {
-	return publicKeyResponse{d.svc.PublicKey()}, nil
+// PublicKey returns the public key of the discharge service.
+func (h dischargeHandler) PublicKey(*publicKeyRequest) (publicKeyResponse, error) {
+	return publicKeyResponse{
+		PublicKey: &h.discharger.p.Key.Public,
+	}, nil
 }
 
+// mkHTTPHandler converts an httprouter handler to an http.Handler,
+// assuming that the httprouter handler has no wildcard path
+// parameters.
+func mkHTTPHandler(h httprouter.Handle) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		h(w, req, nil)
+	})
+}
+
+// randomBytes returns n random bytes.
 func randomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
@@ -123,10 +207,4 @@ func randomBytes(n int) ([]byte, error) {
 		return nil, fmt.Errorf("cannot generate %d random bytes: %v", n, err)
 	}
 	return b, nil
-}
-
-func mkHandler(h httprouter.Handle) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		h(w, req, nil)
-	})
 }


### PR DESCRIPTION
Some external code substantially duplicates the logic
inside the discharger; this PR aims to make that unnecessary.

It also prepares the ground for supporting binary
caveat ids.
