### PR TITLE
checkers: implement serialization for namespaces

### DIFF
--- a/bakery/checkers/namespace.go
+++ b/bakery/checkers/namespace.go
@@ -1,5 +1,14 @@
 package checkers
 
+import (
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	errgo "gopkg.in/errgo.v1"
+)
+
 // Namespace holds maps from schema URIs to the
 // prefixes that are used to encode them in first party
 // caveats. Several different URIs may map to the same
@@ -10,15 +19,78 @@ type Namespace struct {
 }
 
 // NewNamespace returns a new namespace with the
-// given initial contents.
+// given initial contents. It will panic if any of the
+// URI keys or their associated prefix are invalid
+// (see IsValidSchemaURI and IsValidPrefix).
 func NewNamespace(uriToPrefix map[string]string) *Namespace {
 	ns := &Namespace{
 		uriToPrefix: make(map[string]string),
 	}
 	for uri, prefix := range uriToPrefix {
+		ns.Register(uri, prefix)
 		ns.uriToPrefix[uri] = prefix
 	}
 	return ns
+}
+
+// String returns the namespace representation as returned by
+// ns.MarshalText.
+func (ns *Namespace) String() string {
+	data, _ := ns.MarshalText()
+	return string(data)
+}
+
+// MarshalText implements encoding.TextMarshaler by
+// returning all the elements in the namespace sorted by
+// URI, joined to the associated prefix with a colon and
+// separated with spaces.
+func (ns *Namespace) MarshalText() ([]byte, error) {
+	if ns == nil || len(ns.uriToPrefix) == 0 {
+		return nil, nil
+	}
+	uris := make([]string, 0, len(ns.uriToPrefix))
+	dataLen := 0
+	for uri, prefix := range ns.uriToPrefix {
+		uris = append(uris, uri)
+		dataLen += len(uri) + 1 + len(prefix) + 1
+	}
+	sort.Strings(uris)
+	data := make([]byte, 0, dataLen)
+	for i, uri := range uris {
+		if i > 0 {
+			data = append(data, ' ')
+		}
+		data = append(data, uri...)
+		data = append(data, ':')
+		data = append(data, ns.uriToPrefix[uri]...)
+	}
+	return data, nil
+}
+
+func (ns *Namespace) UnmarshalText(data []byte) error {
+	uriToPrefix := make(map[string]string)
+	elems := strings.Fields(string(data))
+	for _, elem := range elems {
+		i := strings.LastIndex(elem, ":")
+		if i == -1 {
+			return errgo.Newf("no colon in namespace field %q", elem)
+		}
+		uri, prefix := elem[0:i], elem[i+1:]
+		if !IsValidSchemaURI(uri) {
+			// Currently this can't happen because the only invalid URIs
+			// are those which contain a space
+			return errgo.Newf("invalid URI %q in namespace field %q", uri, elem)
+		}
+		if !IsValidPrefix(prefix) {
+			return errgo.Newf("invalid prefix %q in namespace field %q", prefix, elem)
+		}
+		if _, ok := uriToPrefix[uri]; ok {
+			return errgo.Newf("duplicate URI %q in namespace %q", uri, data)
+		}
+		uriToPrefix[uri] = prefix
+	}
+	ns.uriToPrefix = uriToPrefix
+	return nil
 }
 
 // EnsureResolved tries to resolve the given schema URI to a prefix and
@@ -77,18 +149,43 @@ func (ns *Namespace) ResolveCaveat(cav Caveat) Caveat {
 // ConditionWithPrefix returns the given string prefixed by the
 // given prefix. If the prefix is non-empty, a colon
 // is used to separate them.
-func ConditionWithPrefix(prefix, s string) string {
+func ConditionWithPrefix(prefix, condition string) string {
 	if prefix == "" {
-		return s
+		return condition
 	}
-	return prefix + ":" + s
+	return prefix + ":" + condition
 }
 
 // Register registers the given URI and associates it
 // with the given prefix. If the URI has already been registered,
 // this is a no-op.
 func (ns *Namespace) Register(uri, prefix string) {
+	if !IsValidSchemaURI(uri) {
+		panic(errgo.Newf("cannot register invalid URI %q (prefix %q)", uri, prefix))
+	}
+	if !IsValidPrefix(prefix) {
+		panic(errgo.Newf("cannot register invalid prefix %q for URI %q", prefix, uri))
+	}
 	if _, ok := ns.uriToPrefix[uri]; !ok {
 		ns.uriToPrefix[uri] = prefix
 	}
+}
+
+func invalidSchemaRune(r rune) bool {
+	return unicode.IsSpace(r)
+}
+
+func IsValidSchemaURI(uri string) bool {
+	// TODO more stringent requirements?
+	return len(uri) > 0 &&
+		utf8.ValidString(uri) &&
+		strings.IndexFunc(uri, invalidSchemaRune) == -1
+}
+
+func invalidPrefixRune(r rune) bool {
+	return r == ' ' || r == ':' || unicode.IsSpace(r)
+}
+
+func IsValidPrefix(prefix string) bool {
+	return utf8.ValidString(prefix) && strings.IndexFunc(prefix, invalidPrefixRune) == -1
 }


### PR DESCRIPTION
This will allow us to pass namespaces around with macaroons
so that clients can know what first party caveats can be added.

A namespace is a many-to-one mapping of schema URI to
prefix which we represent as a space separated set
of URI:prefix pairs.
