### PR TITLE
httpbakery: Add context to to client methods.

### DIFF
--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -917,7 +917,7 @@ func (c *client) requestMacaroons(svc *service) []macaroon.Slice {
 }
 
 func (c *client) dischargeAll(ctxt context.Context, m *macaroon.Macaroon, ns *checkers.Namespace) (macaroon.Slice, error) {
-	return bakery.DischargeAll(ctxt, m, func(cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+	return bakery.DischargeAll(ctxt, m, func(_ context.Context, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 		d := c.dischargers[cav.Location]
 		if d == nil {
 			return nil, errgo.Newf("third party discharger %q not found", cav.Location)

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -55,8 +55,8 @@ func newBakery(location string, locator *bakery.ThirdPartyStore) *bakery.Bakery 
 	return bakery.New(p)
 }
 
-func noDischarge(c *gc.C) func(macaroon.Caveat) (*macaroon.Macaroon, error) {
-	return func(macaroon.Caveat) (*macaroon.Macaroon, error) {
+func noDischarge(c *gc.C) func(context.Context, macaroon.Caveat) (*macaroon.Macaroon, error) {
+	return func(context.Context, macaroon.Caveat) (*macaroon.Macaroon, error) {
 		c.Errorf("getDischarge called unexpectedly")
 		return nil, fmt.Errorf("nothing")
 	}

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -18,7 +18,7 @@ import (
 func DischargeAll(
 	ctxt context.Context,
 	m *macaroon.Macaroon,
-	getDischarge func(cav macaroon.Caveat) (*macaroon.Macaroon, error),
+	getDischarge func(context.Context, macaroon.Caveat) (*macaroon.Macaroon, error),
 ) (macaroon.Slice, error) {
 	return DischargeAllWithKey(ctxt, m, getDischarge, nil)
 }
@@ -35,7 +35,7 @@ func DischargeAll(
 func DischargeAllWithKey(
 	ctxt context.Context,
 	m *macaroon.Macaroon,
-	getDischarge func(cav macaroon.Caveat) (*macaroon.Macaroon, error),
+	getDischarge func(context.Context, macaroon.Caveat) (*macaroon.Macaroon, error),
 	localKey *KeyPair,
 ) (macaroon.Slice, error) {
 	sig := m.Signature()
@@ -58,7 +58,7 @@ func DischargeAllWithKey(
 		if localKey != nil && cav.Location == "local" {
 			dm, _, err = Discharge(ctxt, localKey, localDischargeChecker, cav.Id)
 		} else {
-			dm, err = getDischarge(cav)
+			dm, err = getDischarge(ctxt, cav)
 		}
 		if err != nil {
 			return nil, errgo.NoteMask(err, fmt.Sprintf("cannot get discharge from %q", cav.Location), errgo.Any)

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/juju/testing"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2-unstable"
 
@@ -55,7 +56,7 @@ func (*DischargeSuite) TestDischargeAllManyDischarges(c *gc.C) {
 		}
 	}
 	addCaveats(m0)
-	getDischarge := func(cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+	getDischarge := func(_ context.Context, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 		m, err := macaroon.New([]byte("root key "+string(cav.Id)), cav.Id, "", macaroonCurrentVersion)
 		c.Assert(err, gc.IsNil)
 		addCaveats(m)

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -48,7 +48,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 	}}, dischargeOp)
 
 	c.Assert(err, gc.IsNil)
-	ms, err := s.client.DischargeAll(m)
+	ms, err := s.client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 
@@ -94,7 +94,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	}}, dischargeOp)
 	c.Assert(err, gc.IsNil)
 
-	ms, err := s.client.DischargeAll(m)
+	ms, err := s.client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 3)
 
@@ -107,7 +107,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	ms, err = s.client.DischargeAll(m)
+	ms, err = s.client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://[^"]*": third party refused discharge: cannot discharge: caveat refused`)
 	c.Assert(ms, gc.HasLen, 0)
 }
@@ -174,7 +174,7 @@ func (s *suite) TestInteractiveDischarger(c *gc.C) {
 		var c httprequest.Client
 		return c.Get(u.String(), nil)
 	}
-	ms, err := client.DischargeAll(m)
+	ms, err := client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 
@@ -212,7 +212,7 @@ func (s *suite) TestLoginDischargerError(c *gc.C) {
 		var c httprequest.Client
 		return c.Get(u.String(), nil)
 	}
-	_, err = client.DischargeAll(m)
+	_, err = client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from ".*": failed to acquire macaroon after waiting: third party refused discharge: test error`)
 }
 
@@ -245,7 +245,7 @@ func (s *suite) TestInteractiveDischargerURL(c *gc.C) {
 		var c httprequest.Client
 		return c.Get(u.String(), nil)
 	}
-	ms, err := client.DischargeAll(m)
+	ms, err := client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -105,7 +105,7 @@ func (s *agentSuite) TestAgentLogin(c *gc.C) {
 			bakery.LoginOp,
 		)
 		c.Assert(err, gc.IsNil)
-		ms, err := client.DischargeAll(m)
+		ms, err := client.DischargeAll(context.Background(), m)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			continue
@@ -129,7 +129,7 @@ func (s *agentSuite) TestNoCookieError(c *gc.C) {
 	)
 
 	c.Assert(err, gc.IsNil)
-	_, err = client.DischargeAll(m)
+	_, err = client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.ErrorMatches, "cannot get discharge from .*: cannot start interactive session: no suitable agent found")
 	_, ok := errgo.Cause(err).(*httpbakery.InteractionError)
 	c.Assert(ok, gc.Equals, true)
@@ -190,7 +190,7 @@ func (s *agentSuite) TestMultipleAgents(c *gc.C) {
 		bakery.LoginOp,
 	)
 	c.Assert(err, gc.IsNil)
-	ms, err := client.DischargeAll(m)
+	ms, err := client.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	authInfo, err := s.bakery.Checker.Auth(ms).Allow(context.Background(), bakery.LoginOp)
 	c.Assert(err, gc.IsNil)

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -238,7 +238,7 @@ func assertDischargeServerDischargesConditionForVersion(c *gc.C, cond string, ve
 	}, nil)
 	c.Assert(err, gc.IsNil)
 	client := httpbakery.NewClient()
-	ms, err := client.DischargeAll(m)
+	ms, err := client.DischargeAll(context.TODO(), m)
 	c.Assert(err, gc.IsNil)
 	c.Check(ms, gc.HasLen, 2)
 	c.Check(called, gc.Equals, 1)
@@ -502,7 +502,7 @@ func (s *ClientSuite) TestDischargeAcquirer(c *gc.C) {
 	cl := httpbakery.NewClient()
 	cl.DischargeAcquirer = ta
 
-	ms, err := cl.DischargeAll(m)
+	ms, err := cl.DischargeAll(context.Background(), m)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 2)
 
@@ -527,7 +527,7 @@ type testAcquirer struct {
 }
 
 // AcquireDischarge implements httpbakery.DischargeAcquirer.
-func (ta *testAcquirer) AcquireDischarge(cav macaroon.Caveat) (*macaroon.Macaroon, error) {
+func (ta *testAcquirer) AcquireDischarge(_ context.Context, cav macaroon.Caveat) (*macaroon.Macaroon, error) {
 	ta.acquireCaveat = cav
 	err := ta.dischargeMacaroon.AddFirstPartyCaveat("must foo")
 	if err != nil {
@@ -1026,7 +1026,7 @@ func (s *ClientSuite) TestHandleError(c *gc.C) {
 		},
 	}
 	client := httpbakery.NewClient()
-	err = client.HandleError(u, respErr)
+	err = client.HandleError(context.Background(), u, respErr)
 	c.Assert(err, gc.Equals, nil)
 	// No cookies at the original location.
 	c.Assert(client.Client.Jar.Cookies(u), gc.HasLen, 0)
@@ -1076,7 +1076,7 @@ func (s *ClientSuite) TestHandleErrorDifferentError(c *gc.C) {
 		Code:    "another code",
 	}
 	client := httpbakery.NewClient()
-	err := client.HandleError(&url.URL{}, berr)
+	err := client.HandleError(context.Background(), &url.URL{}, berr)
 	c.Assert(err, gc.Equals, berr)
 }
 

--- a/httpbakery/context_go17.go
+++ b/httpbakery/context_go17.go
@@ -1,0 +1,13 @@
+// +build go1.7
+
+package httpbakery
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+func contextFromRequest(req *http.Request) context.Context {
+	return req.Context()
+}

--- a/httpbakery/context_prego17.go
+++ b/httpbakery/context_prego17.go
@@ -1,0 +1,13 @@
+// +build !go1.7
+
+package httpbakery
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+func contextFromRequest(req *http.Request) context.Context {
+	return context.Background()
+}

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -170,7 +170,7 @@ func (s *formSuite) TestFormLogin(c *gc.C) {
 		}
 		client.WebPageVisitor = httpbakery.NewMultiVisitor(handlers...)
 
-		ms, err := client.DischargeAll(m)
+		ms, err := client.DischargeAll(context.Background(), m)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			continue
@@ -230,7 +230,7 @@ func (s *formSuite) TestFormTitle(c *gc.C) {
 			},
 		)
 
-		ms, err := client.DischargeAll(m)
+		ms, err := client.DischargeAll(context.Background(), m)
 		c.Assert(err, gc.IsNil)
 		c.Assert(len(ms), gc.Equals, 2)
 		c.Assert(f.title, gc.Equals, test.expect)


### PR DESCRIPTION
Add a DoWithContext method and use the context with all HTTP
requests. Also add context to DischargeAll and HandleError methods.