### PR TITLE
bakery: add authorizer helper types

### DIFF
--- a/bakery/authorizer.go
+++ b/bakery/authorizer.go
@@ -2,6 +2,7 @@ package bakery
 
 import (
 	"golang.org/x/net/context"
+	"gopkg.in/errgo.v1"
 
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
@@ -18,7 +19,6 @@ type Authorizer interface {
 	// On success, each element of allowed holds whether the respective
 	// element of ops has been allowed, and caveats holds any additional
 	// third party caveats that apply.
-	//
 	// If allowed is shorter then ops, the additional elements are assumed to
 	// be false.
 	Authorize(ctxt context.Context, id Identity, ops []Op) (allowed []bool, caveats []checkers.Caveat, err error)
@@ -36,6 +36,8 @@ var (
 var (
 	_ Authorizer = OpenAuthorizer
 	_ Authorizer = ClosedAuthorizer
+	_ Authorizer = AuthorizerFunc(nil)
+	_ Authorizer = ACLAuthorizer{}
 )
 
 type openAuthorizer struct{}
@@ -54,4 +56,94 @@ type closedAuthorizer struct{}
 // Authorize implements Authorizer.Authorize.
 func (closedAuthorizer) Authorize(ctxt context.Context, id Identity, ops []Op) (allowed []bool, caveats []checkers.Caveat, err error) {
 	return make([]bool, len(ops)), nil, nil
+}
+
+// AuthorizerFunc implements a simplified version of Authorizer
+// that operates on a single operation at a time.
+type AuthorizerFunc func(ctxt context.Context, id Identity, op Op) (bool, []checkers.Caveat, error)
+
+// Authorize implements Authorizer.Authorize by calling f
+// with the given identity for each operation.
+func (f AuthorizerFunc) Authorize(ctxt context.Context, id Identity, ops []Op) (allowed []bool, caveats []checkers.Caveat, err error) {
+	allowed = make([]bool, len(ops))
+	for i, op := range ops {
+		ok, fcaveats, err := f(ctxt, id, op)
+		if err != nil {
+			return nil, nil, errgo.Mask(err)
+		}
+		allowed[i] = ok
+		// TODO merge identical caveats?
+		caveats = append(caveats, fcaveats...)
+	}
+	return allowed, caveats, nil
+}
+
+// Everyone is recognized by ACLAuthorizer as the name of a
+// group that has everyone in it.
+const Everyone = "everyone"
+
+// ACLIdentity may be implemented by Identity implementions
+// to report group membership information.
+// See ACLAuthorizer for details.
+type ACLIdentity interface {
+	Identity
+
+	// Allow reports whether the user should be allowed to access
+	// any of the users or groups in the given ACL slice.
+	Allow(ctxt context.Context, acl []string) (bool, error)
+}
+
+// ACLAuthorizer is an Authorizer implementation that will check access
+// control list (ACL) membership of users. It uses GetACL to find out
+// the ACLs that apply to the requested operations and will authorize an
+// operation if an ACL contains the group "everyone" or if the context
+// contains an AuthInfo (see ContextWithAuthInfo) that holds an Identity
+// that implements ACLIdentity and its Allow method returns true for the
+// ACL.
+type ACLAuthorizer struct {
+	// If AllowPublic is true and an ACL contains "everyone",
+	// then authorization will be granted even if there is
+	// no logged in user.
+	AllowPublic bool
+
+	// GetACL returns the ACL that applies to the given operation.
+	// If an entity cannot be found or the action is not recognised,
+	// GetACLs should return an empty ACL but no error.
+	GetACL func(ctxt context.Context, op Op) ([]string, error)
+}
+
+// Authorize implements Authorizer.Authorize by calling ident.Allow to determine
+// whether the identity is a member of the ACLs associated with the given
+// operations.
+func (a ACLAuthorizer) Authorize(ctxt context.Context, ident Identity, ops []Op) (allowed []bool, caveats []checkers.Caveat, err error) {
+	if len(ops) == 0 {
+		// Anyone is allowed to do nothing.
+		return nil, nil, nil
+	}
+	ident1, _ := ident.(ACLIdentity)
+	allowed = make([]bool, len(ops))
+	for i, op := range ops {
+		acl, err := a.GetACL(ctxt, op)
+		if err != nil {
+			return nil, nil, errgo.Mask(err)
+		}
+		if ident1 != nil {
+			allowed[i], err = ident1.Allow(ctxt, acl)
+			if err != nil {
+				return nil, nil, errgo.Notef(err, "cannot check permissions")
+			}
+		} else {
+			allowed[i] = a.AllowPublic && isPublicACL(acl)
+		}
+	}
+	return allowed, nil, nil
+}
+
+func isPublicACL(acl []string) bool {
+	for _, g := range acl {
+		if g == Everyone {
+			return true
+		}
+	}
+	return false
 }

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2-unstable"
@@ -17,12 +18,12 @@ import (
 // time-before caveats will always be the value of epoch.
 var testContext = checkers.ContextWithClock(context.Background(), stoppedClock{epoch})
 
+var logger = loggo.GetLogger("bakery.bakery_test")
+
 var (
 	epoch = time.Date(1900, 11, 17, 19, 00, 13, 0, time.UTC)
 	ages  = epoch.Add(24 * time.Hour)
 )
-
-var loginOps = []bakery.Op{bakery.LoginOp}
 
 var testChecker = func() *checkers.Checker {
 	c := checkers.New(nil)

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -83,7 +83,7 @@ func (*DischargeSuite) TestDischargeAllLocalDischarge(c *gc.C) {
 	ms, err := bakery.DischargeAllWithKey(testContext, m, noDischarge(c), clientKey)
 	c.Assert(err, gc.IsNil)
 
-	_, err = oc.Checker.Auth(ms).Allow(testContext, loginOps...)
+	_, err = oc.Checker.Auth(ms).Allow(testContext, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/bakery/doc.go
+++ b/bakery/doc.go
@@ -2,6 +2,21 @@
 // a transport and store-agnostic way of using macaroons to assert
 // client capabilities.
 //
+// Summary
+//
+// The Bakery type is probably where you want to start.
+// It encapsulates a Checker type, which performs checking
+// of operations, and an Oven type, which encapsulates
+// the actual details of the macaroon encoding conventions.
+//
+// Most other types and functions are designed either to plug
+// into one of the above types (the various Authorizer
+// implementations, for example), or to expose some independent
+// functionality that's potentially useful (Discharge, for example).
+//
+// The rest of this introduction introduces some of the concepts
+// used by the bakery package.
+//
 // Identity and entities
 //
 // An Identity represents some authenticated user (or agent), usually

--- a/bakery/service.go
+++ b/bakery/service.go
@@ -1,7 +1,3 @@
-// The bakery package layers on top of the macaroon package, providing
-// a transport and store-agnostic way of using macaroons to assert
-// client capabilities.
-//
 package bakery
 
 import (


### PR DESCRIPTION
These are designed to help writing tests and to support
our usual ACL model.

We also update the package docs a bit.
