### PR TITLE
httpbakery/agent: export Agent type

### DIFF
--- a/httpbakery/agent/discharge_test.go
+++ b/httpbakery/agent/discharge_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -103,7 +102,6 @@ func (d *Discharger) GetAgentLogin(r *http.Request) (*agent.AgentLogin, error) {
 }
 
 func (d *Discharger) finishWait(w http.ResponseWriter, r *http.Request, identity bakery.Identity) {
-	log.Printf("finish wait, identity %#v", identity)
 	r.ParseForm()
 	id, err := strconv.Atoi(r.Form.Get("waitid"))
 	if err != nil {

--- a/httpbakery/agent/export_test.go
+++ b/httpbakery/agent/export_test.go
@@ -3,5 +3,5 @@ package agent
 type AgentLogin agentLogin
 type AgentResponse agentResponse
 
-var PathCmp = pathCmp
 var SetCookie = setCookie
+var FindAgent = (*Visitor).findAgent

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -109,7 +109,7 @@ var checkerTests = []struct {
 		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
 			RemoteAddr: "bad",
 		}),
-		expectError: `caveat "error cannot parse host port in remote address: missing port in address bad" not satisfied: bad caveat`,
+		expectError: `caveat "error cannot parse host port in remote address: .*" not satisfied: bad caveat`,
 	}, {
 		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
 			RemoteAddr: "bad:56",


### PR DESCRIPTION
We export the Agent type in preparation for providing
serialization support for Visitor. We also
make Agent the internal representation too
and use a slightly more efficient, allocation-free, lookup
algorithm.