### PR TITLE
bakery/checkers: make ResolveCaveat always resolve

### DIFF
--- a/bakery/checkers/namespace.go
+++ b/bakery/checkers/namespace.go
@@ -136,7 +136,11 @@ func (ns *Namespace) ResolveCaveat(cav Caveat) Caveat {
 	}
 	prefix, ok := ns.Resolve(cav.Namespace)
 	if !ok {
-		return ErrorCaveatf("caveat %q in unregistered namespace %q", cav.Condition, cav.Namespace)
+		errCav := ErrorCaveatf("caveat %q in unregistered namespace %q", cav.Condition, cav.Namespace)
+		if errCav.Namespace != cav.Namespace {
+			prefix, _ = ns.Resolve(errCav.Namespace)
+		}
+		cav = errCav
 	}
 	if prefix != "" {
 		cav.Condition = ConditionWithPrefix(prefix, cav.Condition)

--- a/bakery/checkers/namespace_test.go
+++ b/bakery/checkers/namespace_test.go
@@ -113,7 +113,6 @@ var resolveCaveatTests = []struct {
 	},
 	expect: checkers.Caveat{
 		Condition: `error caveat "foo" in unregistered namespace "testns"`,
-		Namespace: checkers.StdNamespace,
 	},
 }, {
 	about: "with empty prefix",


### PR DESCRIPTION
Guarantee that even if Namespace.ResolveCaveat can't resolve the
namespace for the error caveat, it still produces a caveat without
a namespace.
