### PR TITLE
 bakery: allow LoginOp auth without macaroon

### DIFF
--- a/bakery/checker.go
+++ b/bakery/checker.go
@@ -295,7 +295,13 @@ func (a *AuthChecker) allowAny(ctxt context.Context, ops []Op) (authed, used []b
 			authed[i] = true
 			numAuthed++
 			used[mindex] = true
+			// Use the first authorized macaroon only.
 			break
+		}
+		if op == LoginOp && !authed[i] && a.identity != nil {
+			// Allow LoginOp when there's an authenticated user even
+			// when there's no macaroon that specifically authorizes it.
+			authed[i] = true
 		}
 	}
 	if a.identity != nil {

--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -427,6 +427,18 @@ func (s *checkerSuite) TestAuthWithIdentityFromContext(c *gc.C) {
 	c.Assert(authInfo.Macaroons, gc.HasLen, 0)
 }
 
+func (s *checkerSuite) TestAuthLoginOpWithIdentityFromContext(c *gc.C) {
+	locator := make(dischargerLocator)
+	ids := basicAuthIdService{}
+	ts := newService(nil, ids, locator)
+
+	// Check that we can use LoginOp when auth isn't granted through macaroons.
+	authInfo, err := newClient(locator).do(contextWithBasicAuth(testContext, "sherlock", "holmes"), ts, bakery.LoginOp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(authInfo.Identity, gc.Equals, simpleIdentity("sherlock"))
+	c.Assert(authInfo.Macaroons, gc.HasLen, 0)
+}
+
 func (s *checkerSuite) TestOperationAllowCaveat(c *gc.C) {
 	locator := make(dischargerLocator)
 	ids := s.newIdService("ids", locator)


### PR DESCRIPTION
LoginOp is special - it is authorized
whenever you have an authenticated identity, regardless
of whether there's a macaroon or not.