### PR TITLE
bakery/checkers: simplify declarations

### DIFF
--- a/bakery/checker.go
+++ b/bakery/checker.go
@@ -128,18 +128,27 @@ func (c *Checker) Auth(mss ...macaroon.Slice) *AuthChecker {
 type AuthChecker struct {
 	// Checker is used to check first party caveats.
 	*Checker
+
+	// macaroons holds the macaroons providing authorization.
 	macaroons []macaroon.Slice
+
+	// initOnce guards all the fields below it.
+	initOnce   sync.Once
+	initError  error
+	initErrors []error
 	// conditions holds the first party caveat conditions
 	// that apply to each of the above macaroons.
-	conditions      [][]string
-	initOnce        sync.Once
-	initError       error
-	initErrors      []error
-	identity        Identity
+	conditions [][]string
+	// identity holds the authenticated idenity.
+	identity Identity
+	// When identity is nil, identityCaveats may hold the third party caveats that
+	// can be used to make a macaroon that will prove the identity.
 	identityCaveats []checkers.Caveat
 	// authIndexes holds for each potentially authorized operation
 	// the indexes of the macaroons that authorize it.
 	authIndexes map[Op][]int
+	// declarationCondition holds the resolved identity declaration condition
+	declarationCondition string
 }
 
 func (a *AuthChecker) init(ctxt context.Context) error {
@@ -150,6 +159,15 @@ func (a *AuthChecker) init(ctxt context.Context) error {
 }
 
 func (a *AuthChecker) initOnceFunc(ctxt context.Context) error {
+	if cav := a.p.IdentityClient.DeclarationCaveat(); cav.Condition != "" {
+		// Don't use ResolveCaveat because we want to return an error immediately
+		// if we can't resolve the namespace.
+		prefix, ok := a.Namespace().Resolve(cav.Namespace)
+		if !ok {
+			return errgo.Newf("cannot resolve declaration caveat namespace %q", cav.Namespace)
+		}
+		a.declarationCondition = checkers.ConditionWithPrefix(prefix, cav.Condition)
+	}
 	a.authIndexes = make(map[Op][]int)
 	a.conditions = make([][]string, len(a.macaroons))
 	for i, ms := range a.macaroons {
@@ -404,7 +422,9 @@ func (a *AuthChecker) AllowCapability(ctxt context.Context, ops ...Op) ([]string
 	if err != nil {
 		return nil, errgo.Mask(err, isDischargeRequiredError)
 	}
-	var squasher caveatSquasher
+	squasher := &caveatSquasher{
+		declarationCondition: a.declarationCondition,
+	}
 	for i, isUsed := range used {
 		if !isUsed {
 			continue
@@ -424,8 +444,9 @@ func (a *AuthChecker) AllowCapability(ctxt context.Context, ops ...Op) ([]string
 //	- removing declared caveats.
 //	- removing duplicates.
 type caveatSquasher struct {
-	expiry time.Time
-	conds  []string
+	declarationCondition string
+	expiry               time.Time
+	conds                []string
 }
 
 func (c *caveatSquasher) add(cond string) {
@@ -434,6 +455,8 @@ func (c *caveatSquasher) add(cond string) {
 	}
 }
 
+// add0 adds the caveat to the squasher. It reports whether
+// the caveat should actually be added.
 func (c *caveatSquasher) add0(cond string) bool {
 	cond, args, err := checkers.ParseCaveat(cond)
 	if err != nil {
@@ -453,7 +476,7 @@ func (c *caveatSquasher) add0(cond string) bool {
 		return false
 	case checkers.CondAllow,
 		checkers.CondDeny,
-		checkers.CondDeclared:
+		c.declarationCondition:
 		return false
 	}
 	return true
@@ -481,14 +504,17 @@ func (c *caveatSquasher) final() []string {
 	return c.conds
 }
 
-func (a *AuthChecker) checkConditions(ctxt context.Context, op Op, conds []string) (map[string]string, error) {
-	declared := checkers.InferDeclaredFromConditions(a.Namespace(), conds)
-	ctxt = checkers.ContextWithOperations(ctxt, op.Action)
-	ctxt = checkers.ContextWithDeclared(ctxt, declared)
+func (a *AuthChecker) checkConditions(ctx context.Context, op Op, conds []string) (string, error) {
+	var declared checkers.Declared
+	if a.declarationCondition != "" {
+		declared = checkers.InferDeclared(a.declarationCondition, conds)
+		ctx = checkers.ContextWithDeclared(ctx, declared)
+	}
+	ctx = checkers.ContextWithOperations(ctx, op.Action)
 	for _, cond := range conds {
-		if err := a.CheckFirstPartyCaveat(ctxt, cond); err != nil {
-			return nil, errgo.Mask(err)
+		if err := a.CheckFirstPartyCaveat(ctx, cond); err != nil {
+			return "", errgo.Mask(err)
 		}
 	}
-	return declared, nil
+	return declared.Value, nil
 }

--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -18,7 +18,6 @@ const StdNamespace = "std"
 // First and third party caveat conditions are both defined here,
 // even though notionally they exist in separate name spaces.
 const (
-	CondDeclared   = "declared"
 	CondTimeBefore = "time-before"
 	CondError      = "error"
 	CondAllow      = "allow"
@@ -26,6 +25,7 @@ const (
 )
 
 const (
+	// TODO(rog) remove this.
 	CondNeedDeclared = "need-declared"
 )
 
@@ -50,7 +50,6 @@ type CheckerInfo struct {
 
 var allCheckers = map[string]Func{
 	CondTimeBefore: checkTimeBefore,
-	CondDeclared:   checkDeclared,
 	CondAllow:      checkAllow,
 	CondDeny:       checkDeny,
 	CondError:      checkError,

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -5,35 +5,15 @@ import (
 
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/macaroon.v2-unstable"
 )
 
-type declaredKey struct{}
-
-// ContextWithDeclared returns a context with attached declared information,
-// as returned from InferDeclared.
-func ContextWithDeclared(ctxt context.Context, declared map[string]string) context.Context {
-	return context.WithValue(ctxt, declaredKey{}, declared)
-}
-
-func declaredFromContext(ctxt context.Context) map[string]string {
-	m, _ := ctxt.Value(declaredKey{}).(map[string]string)
-	return m
-}
-
-// DeclaredCaveat returns a "declared" caveat asserting that the given key is
-// set to the given value. If a macaroon has exactly one first party
-// caveat asserting the value of a particular key, then InferDeclared
-// will be able to infer the value, and then DeclaredChecker will allow
-// the declared value if it has the value specified here.
-//
-// If the key is empty or contains a space, DeclaredCaveat
-// will return an error caveat.
-func DeclaredCaveat(key string, value string) Caveat {
-	if strings.Contains(key, " ") || key == "" {
-		return ErrorCaveatf("invalid caveat 'declared' key %q", key)
-	}
-	return firstParty(CondDeclared, key+" "+value)
+// Declared represents a value declared by virtue of being
+// present as a first-party caveat.
+type Declared struct {
+	// Condition holds the resolved caveat condition.
+	Condition string
+	// Value holds the declared argument to the condition.
+	Value string
 }
 
 // NeedDeclaredCaveat returns a third party caveat that
@@ -41,6 +21,7 @@ func DeclaredCaveat(key string, value string) Caveat {
 // that the third party must add "declared" caveats for
 // all the named keys.
 // TODO(rog) namespaces in third party caveats?
+// TODO(rog) deprecate this in favour of in-built field in third party caveat format.
 func NeedDeclaredCaveat(cav Caveat, keys ...string) Caveat {
 	if cav.Location == "" {
 		return ErrorCaveatf("need-declared caveat is not third-party")
@@ -51,73 +32,56 @@ func NeedDeclaredCaveat(cav Caveat, keys ...string) Caveat {
 	}
 }
 
-func checkDeclared(ctxt context.Context, _, arg string) error {
-	parts := strings.SplitN(arg, " ", 2)
-	if len(parts) != 2 {
-		return errgo.Newf("declared caveat has no value")
-	}
-	attrs := declaredFromContext(ctxt)
-	val, ok := attrs[parts[0]]
-	if !ok {
-		return errgo.Newf("got %s=null, expected %q", parts[0], parts[1])
-	}
-	if val != parts[1] {
-		return errgo.Newf("got %s=%q, expected %q", parts[0], val, parts[1])
+type declaredKey string
+
+// ContextWithDeclared returns a context with attached declared information,
+// as returned from InferDeclared.
+func ContextWithDeclared(ctxt context.Context, declared Declared) context.Context {
+	return context.WithValue(ctxt, declaredKey(declared.Condition), declared.Value)
+}
+
+func declaredFromContext(ctxt context.Context, cond string) string {
+	val, _ := ctxt.Value(declaredKey(cond)).(string)
+	return val
+}
+
+// RegisterDeclaredCaveat registers a checker for the given declaration
+// caveat in the given namespace URI. Caveats with the
+// given condition will succeed if the context is associated with a
+// Declared value that has the same condition as its argument.
+// (see ContextWithDeclared).
+func RegisterDeclaredCaveat(c *Checker, cond, uri string) {
+	c.Register(cond, uri, checkDeclared)
+}
+
+func checkDeclared(ctx context.Context, cond, arg string) error {
+	if val := declaredFromContext(ctx, cond); arg != val {
+		return errgo.Newf("got %q, expected %q", arg, val)
 	}
 	return nil
 }
 
-// InferDeclared retrieves any declared information from
-// the given macaroons and returns it as a key-value map.
+// InferDeclared infers a declared value for the given caveat condition, which
+// should be a resolved caveat condition including its prefix, but without
+// any argument.
 //
-// Information is declared with a first party caveat as created
-// by DeclaredCaveat.
-//
-// If there are two caveats that declare the same key with
-// different values, the information is omitted from the map.
-// When the caveats are later checked, this will cause the
-// check to fail.
-func InferDeclared(ns *Namespace, ms macaroon.Slice) map[string]string {
-	var conditions []string
-	for _, m := range ms {
-		for _, cav := range m.Caveats() {
-			if cav.Location == "" {
-				conditions = append(conditions, string(cav.Id))
-			}
-		}
-	}
-	return InferDeclaredFromConditions(ns, conditions)
-}
-
-// InferDeclaredFromConditions is like InferDeclared except that
-// it is passed a set of first party caveat conditions rather than a set of macaroons.
-func InferDeclaredFromConditions(ns *Namespace, conds []string) map[string]string {
-	var conflicts []string
-	// If we can't resolve that standard namespace, then we'll look for
-	// just bare "declared" caveats which will work OK for legacy
-	// macaroons with no namespace.
-	prefix, _ := ns.Resolve(StdNamespace)
-	declaredCond := prefix + CondDeclared
-
-	info := make(map[string]string)
+// The conditions are assumed to be first party caveat conditions.
+// If the condition is not present, or is declared more than once with different values,
+// the resulting Declared value will have an empty Value field.
+func InferDeclared(declCond string, conds []string) Declared {
+	val, found := "", false
 	for _, cond := range conds {
-		name, rest, _ := ParseCaveat(cond)
-		if name != declaredCond {
-			continue
+		name, arg, _ := ParseCaveat(cond)
+		switch {
+		case name != declCond:
+		case !found:
+			val, found = arg, true
+		case arg != val:
+			val = ""
 		}
-		parts := strings.SplitN(rest, " ", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key, val := parts[0], parts[1]
-		if oldVal, ok := info[key]; ok && oldVal != val {
-			conflicts = append(conflicts, key)
-			continue
-		}
-		info[key] = val
 	}
-	for _, key := range conflicts {
-		delete(info, key)
+	return Declared{
+		Condition: declCond,
+		Value:     val,
 	}
-	return info
 }

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -30,6 +30,7 @@ var testChecker = func() *checkers.Checker {
 	c.Namespace().Register("testns", "")
 	c.Register("str", "testns", strCheck)
 	c.Register("true", "testns", trueCheck)
+	checkers.RegisterDeclaredCaveat(c, "declared", checkers.StdNamespace)
 	return c
 }()
 
@@ -73,7 +74,11 @@ func (oneIdentity) IdentityFromContext(ctxt context.Context) (bakery.Identity, [
 	return nil, nil, nil
 }
 
-func (oneIdentity) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+func (oneIdentity) DeclarationCaveat() checkers.Caveat {
+	return checkers.Caveat{}
+}
+
+func (oneIdentity) DeclaredIdentity(string) (bakery.Identity, error) {
 	return noone{}, nil
 }
 

--- a/bakery/identity.go
+++ b/bakery/identity.go
@@ -23,10 +23,17 @@ type IdentityClient interface {
 	// no identity found and no third party to address caveats to.
 	IdentityFromContext(ctxt context.Context) (Identity, []checkers.Caveat, error)
 
+	// DeclarationCaveat returns the caveat that is used to declare
+	// the identity. By convention, the condition should have no argument.
+	// Implementations that do not support declaration caveats
+	// may return the zero caveat.
+	DeclarationCaveat() checkers.Caveat
+
 	// DeclaredIdentity parses the identity declaration from the given
-	// declared attributes.
-	// TODO take the set of first party caveat conditions instead?
-	DeclaredIdentity(declared map[string]string) (Identity, error)
+	// declared value, which is taken from the caveats matching the
+	// value returned from DeclarationCaveat. If any of them hold
+	// different values, this method will not be invoked.
+	DeclaredIdentity(declaredValue string) (Identity, error)
 }
 
 // Identity holds identity information declared in a first party caveat
@@ -53,9 +60,15 @@ func (noIdentities) IdentityFromContext(ctxt context.Context) (Identity, []check
 	return nil, nil, nil
 }
 
+// DeclarationCaveat implements IdentityClient.DeclarationCaveat
+// by returning the empty caveat.
+func (noIdentities) DeclarationCaveat() checkers.Caveat {
+	return checkers.Caveat{}
+}
+
 // DeclaredIdentity implements IdentityClient.DeclaredIdentity by
 // always returning an error.
-func (noIdentities) DeclaredIdentity(declared map[string]string) (Identity, error) {
+func (noIdentities) DeclaredIdentity(string) (Identity, error) {
 	return nil, errgo.Newf("no identity declared or possible")
 }
 


### PR DESCRIPTION
As implied by the proposal document, we make declaration caveats simpler
and hopefully a little less error prone.

In the new scheme, instead of being able to declare an arbitrary
set of attribute/value pairs, each third party will in general use
only a single caveat to declare its information.

This should be less vulnerable to security flaws due to
attributes being added, because all attributes should be declared
within the same caveat.

For backward compatibility, we still support a limited form
of the old scheme, sufficient to declare a single attribute.
This should be sufficient for our existing identity manager
which always uses "declared username" and declares no other
attributes.

The need-declared mechanism is due to change too - we
still support the old scheme, but will implement the new scheme
in a subsequent PR.