### PR TITLE
bakery: use []byte not string for third party caveat condition

### DIFF
--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -236,7 +236,7 @@ func (s *checkerSuite) TestAuthWithThirdPartyCaveats(c *gc.C) {
 	locator["other third party"] = &discharger{
 		key: mustGenerateKey(),
 		checker: bakery.ThirdPartyCaveatCheckerFunc(func(ctxt context.Context, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-			if info.Condition != "question" {
+			if string(info.Condition) != "question" {
 				return nil, errgo.Newf("third party condition not recognized")
 			}
 			s.discharges = append(s.discharges, dischargeRecord{
@@ -630,7 +630,7 @@ func (s *checkerSuite) newIdService(location string, locator dischargerLocator) 
 }
 
 func (ids *idService) CheckThirdPartyCaveat(ctxt context.Context, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-	if info.Condition != "is-authenticated-user" {
+	if string(info.Condition) != "is-authenticated-user" {
 		return nil, errgo.Newf("third party condition not recognized")
 	}
 	username := dischargeUserFromContext(ctxt)

--- a/bakery/codec_test.go
+++ b/bakery/codec_test.go
@@ -36,7 +36,7 @@ func (s *codecSuite) TestV1RoundTrip(c *gc.C) {
 	c.Assert(res, jc.DeepEquals, &ThirdPartyCaveatInfo{
 		FirstPartyPublicKey: s.firstPartyKey.Public,
 		RootKey:             []byte("a random string"),
-		Condition:           "is-authenticated-user",
+		Condition:           []byte("is-authenticated-user"),
 		Caveat:              cid,
 		ThirdPartyKeyPair:   *s.thirdPartyKey,
 		Version:             Version1,
@@ -54,7 +54,7 @@ func (s *codecSuite) TestV2RoundTrip(c *gc.C) {
 	c.Assert(res, jc.DeepEquals, &ThirdPartyCaveatInfo{
 		FirstPartyPublicKey: s.firstPartyKey.Public,
 		RootKey:             []byte("a random string"),
-		Condition:           "is-authenticated-user",
+		Condition:           []byte("is-authenticated-user"),
 		Caveat:              cid,
 		ThirdPartyKeyPair:   *s.thirdPartyKey,
 		Version:             Version2,
@@ -75,7 +75,7 @@ func (s *codecSuite) TestV3RoundTrip(c *gc.C) {
 	c.Assert(res, jc.DeepEquals, &ThirdPartyCaveatInfo{
 		FirstPartyPublicKey: s.firstPartyKey.Public,
 		RootKey:             []byte("a random string"),
-		Condition:           "is-authenticated-user",
+		Condition:           []byte("is-authenticated-user"),
 		Caveat:              cid,
 		ThirdPartyKeyPair:   *s.thirdPartyKey,
 		Version:             Version3,
@@ -146,7 +146,7 @@ func (s *codecSuite) TestV2EmptyRootKey(c *gc.C) {
 	c.Assert(res, jc.DeepEquals, &ThirdPartyCaveatInfo{
 		FirstPartyPublicKey: s.firstPartyKey.Public,
 		RootKey:             []byte{},
-		Condition:           "is-authenticated-user",
+		Condition:           []byte("is-authenticated-user"),
 		Caveat:              cid,
 		ThirdPartyKeyPair:   *s.thirdPartyKey,
 		Version:             Version2,
@@ -163,7 +163,7 @@ func (s *codecSuite) TestV2LongRootKey(c *gc.C) {
 	c.Assert(res, jc.DeepEquals, &ThirdPartyCaveatInfo{
 		FirstPartyPublicKey: s.firstPartyKey.Public,
 		RootKey:             bytes.Repeat([]byte{0}, 65536),
-		Condition:           "is-authenticated-user",
+		Condition:           []byte("is-authenticated-user"),
 		Caveat:              cid,
 		ThirdPartyKeyPair:   *s.thirdPartyKey,
 		Version:             Version2,

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -125,7 +125,7 @@ func strCheck(ctxt context.Context, cond, args string) error {
 type thirdPartyStrcmpChecker string
 
 func (c thirdPartyStrcmpChecker) CheckThirdPartyCaveat(_ context.Context, cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-	if cavInfo.Condition != string(c) {
+	if string(cavInfo.Condition) != string(c) {
 		return nil, fmt.Errorf("%s doesn't match %s", cavInfo.Condition, c)
 	}
 	return nil, nil

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -97,7 +97,7 @@ func DischargeAllWithKey(
 }
 
 var localDischargeChecker = ThirdPartyCaveatCheckerFunc(func(_ context.Context, info *ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-	if info.Condition != "true" {
+	if string(info.Condition) != "true" {
 		return nil, checkers.ErrCaveatNotRecognized
 	}
 	return nil, nil

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -89,7 +89,7 @@ func (*DischargeSuite) TestDischargeAllManyDischargesWithRealThirdPartyCaveats(c
 	const totalDischargesRequired = 40
 	stillRequired := totalDischargesRequired
 	checker := func(_ context.Context, ci *bakery.ThirdPartyCaveatInfo) (caveats []checkers.Caveat, _ error) {
-		if ci.Condition != "something" {
+		if string(ci.Condition) != "something" {
 			return nil, errgo.Newf("unexpected condition")
 		}
 		for i := 0; i < 3; i++ {

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -140,7 +140,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithoutDischarges(c *gc.C) {
 
 	// client makes request to ts
 	_, err = ts.Checker.Auth(macaroon.Slice{tsMacaroon.M()}).Allow(testContext, bakery.LoginOp)
-	c.Assert(err, gc.ErrorMatches, `permission denied: verification failed: cannot find discharge macaroon for caveat .*`, gc.Commentf("%#v", err))
+	c.Assert(err, gc.ErrorMatches, `verification failed: cannot find discharge macaroon for caveat .*`, gc.Commentf("%#v", err))
 }
 
 // TestMacaroonPaperFig6FailsWithBindingOnTamperedSignature runs a similar test as TestMacaroonPaperFig6
@@ -175,7 +175,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithBindingOnTamperedSignature(
 	// client makes request to ts.
 	_, err = ts.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
 	// TODO fix this error message.
-	c.Assert(err, gc.ErrorMatches, "permission denied: verification failed: signature mismatch after caveat verification")
+	c.Assert(err, gc.ErrorMatches, "verification failed: signature mismatch after caveat verification")
 }
 
 func discharge(ctx context.Context, oven *bakery.Oven, checker bakery.ThirdPartyCaveatChecker, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
@@ -275,7 +275,7 @@ func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 
 	ctxt = checkers.ContextWithDeclared(testContext, declared)
 	_, err = firstParty.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
-	c.Assert(err, gc.ErrorMatches, `permission denied: cannot authorize login macaroon: caveat "declared foo a" not satisfied: got foo=null, expected "a"`)
+	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo a" not satisfied: got foo=null, expected "a"`)
 }
 
 func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
@@ -322,7 +322,7 @@ func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
 	// Since no declarations are added by the discharger,
 	d, err = bakery.DischargeAll(testContext, m, func(ctx context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
 		return discharge(ctx, thirdParty.Oven, bakery.ThirdPartyCaveatCheckerFunc(func(_ context.Context, cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-			switch cavInfo.Condition {
+			switch string(cavInfo.Condition) {
 			case "x":
 				return []checkers.Caveat{
 					checkers.DeclaredCaveat("foo", "fooval1"),
@@ -346,7 +346,7 @@ func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
 	})
 	ctxt = checkers.ContextWithDeclared(testContext, declared)
 	_, err = firstParty.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
-	c.Assert(err, gc.ErrorMatches, `permission denied: cannot authorize login macaroon: caveat "declared foo fooval1" not satisfied: got foo=null, expected "fooval1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo fooval1" not satisfied: got foo=null, expected "fooval1"`)
 }
 
 func (s *ServiceSuite) TestDischargeMacaroonCannotBeUsedAsNormalMacaroon(c *gc.C) {

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -123,7 +123,7 @@ func NewDischarger(
 // It parses the caveat's condition and calls the function with the result.
 func ConditionParser(check func(cond, arg string) ([]checkers.Caveat, error)) httpbakery.ThirdPartyCaveatChecker {
 	f := func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-		cond, arg, err := checkers.ParseCaveat(cav.Condition)
+		cond, arg, err := checkers.ParseCaveat(string(cav.Condition))
 		if err != nil {
 			return nil, err
 		}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -7,7 +7,7 @@ github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	b8689951f6db31943dd8c3d540b8c4dd368cf850	2016-10-31T10:37:13Z
 github.com/juju/utils	git	ff639f825faac294524c2fff065f58fed5bcd77e	2016-11-01T02:02:32Z
-github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
+github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
@@ -16,8 +16,9 @@ github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	8e06e8ddd9629eb88639aba897641bff8031f1d3	2016-09-22T17:06:29Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
+golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:20Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
-gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
+gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/macaroon.v2-unstable	git	e4c879958311648cb7f2c2b97290bee05c02718d	2016-11-18T07:12:15Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -220,7 +220,7 @@ func assertDischargeServerDischargesConditionForVersion(c *gc.C, cond string, ve
 	called := 0
 	checker := func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 		called++
-		c.Check(cav.Condition, gc.Equals, cond)
+		c.Check(string(cav.Condition), gc.Equals, cond)
 		return nil, nil
 	}
 	discharger := bakerytest.NewDischarger(nil, httpbakery.ThirdPartyCaveatCheckerFunc(checker))
@@ -313,7 +313,7 @@ func (s *ClientSuite) TestDischargeServerWithMacaraqOnDischarge(c *gc.C) {
 	db1 := newBakery("loc", locator, nil)
 	key2, h2 := newHTTPDischarger(db1, httpbakery.ThirdPartyCaveatCheckerFunc(func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 		called[2]++
-		if cav.Condition != "is-ok" {
+		if string(cav.Condition) != "is-ok" {
 			return nil, fmt.Errorf("unrecognized caveat at srv2")
 		}
 		return nil, nil
@@ -335,7 +335,7 @@ func (s *ClientSuite) TestDischargeServerWithMacaraqOnDischarge(c *gc.C) {
 				authLocation: srv2.URL,
 			}, err, req)
 		}
-		if cav.Condition != "is-ok" {
+		if string(cav.Condition) != "is-ok" {
 			return nil, fmt.Errorf("unrecognized caveat at srv1")
 		}
 		return nil, nil
@@ -373,7 +373,7 @@ func (s *ClientSuite) TestTwoDischargesRequired(c *gc.C) {
 
 	dischargeCount := 0
 	checker := func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-		c.Check(cav.Condition, gc.Equals, "is-ok")
+		c.Check(string(cav.Condition), gc.Equals, "is-ok")
 		dischargeCount++
 		return nil, nil
 	}


### PR DESCRIPTION
This paves the way for encoding more information compactly
inside a third party caveat.