### PR TITLE
use standardized spelling for "ctx"

### DIFF
--- a/bakery/authorizer_test.go
+++ b/bakery/authorizer_test.go
@@ -18,8 +18,8 @@ type authorizerSuite struct {
 var _ = gc.Suite(&authorizerSuite{})
 
 func (*authorizerSuite) TestAuthorizerFunc(c *gc.C) {
-	f := func(ctxt context.Context, id bakery.Identity, op bakery.Op) (bool, []checkers.Caveat, error) {
-		c.Assert(ctxt, gc.Equals, testContext)
+	f := func(ctx context.Context, id bakery.Identity, op bakery.Op) (bool, []checkers.Caveat, error) {
+		c.Assert(ctx, gc.Equals, testContext)
 		c.Assert(id, gc.Equals, bakery.SimpleIdentity("bob"))
 		switch op.Entity {
 		case "a":
@@ -62,7 +62,7 @@ var aclAuthorizerTests = []struct {
 }{{
 	about: "no ops, no problem",
 	auth: bakery.ACLAuthorizer{
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			return nil, nil
 		},
 	},
@@ -70,7 +70,7 @@ var aclAuthorizerTests = []struct {
 	about: "identity that does not implement ACLIdentity; user should be denied except for everyone group",
 	auth: bakery.ACLAuthorizer{
 		AllowPublic: true,
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			if op.Entity == "a" {
 				return []string{bakery.Everyone}, nil
 			} else {
@@ -91,7 +91,7 @@ var aclAuthorizerTests = []struct {
 	about: "identity that does not implement ACLIdentity with user == Id; user should be denied except for everyone group",
 	auth: bakery.ACLAuthorizer{
 		AllowPublic: true,
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			if op.Entity == "a" {
 				return []string{bakery.Everyone}, nil
 			} else {
@@ -111,7 +111,7 @@ var aclAuthorizerTests = []struct {
 }, {
 	about: "permission denied for everyone without AllowPublic",
 	auth: bakery.ACLAuthorizer{
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			return []string{bakery.Everyone}, nil
 		},
 	},
@@ -125,7 +125,7 @@ var aclAuthorizerTests = []struct {
 	about: "permission granted to anyone with no identity with AllowPublic",
 	auth: bakery.ACLAuthorizer{
 		AllowPublic: true,
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			return []string{bakery.Everyone}, nil
 		},
 	},
@@ -138,7 +138,7 @@ var aclAuthorizerTests = []struct {
 	about: "error return causes all authorization to fail",
 	auth: bakery.ACLAuthorizer{
 		AllowPublic: true,
-		GetACL: func(ctxt context.Context, op bakery.Op) ([]string, error) {
+		GetACL: func(ctx context.Context, op bakery.Op) ([]string, error) {
 			if op.Entity == "a" {
 				return []string{bakery.Everyone}, nil
 			} else {

--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -33,7 +33,7 @@ const (
 // cond parameter will hold the caveat condition including any namespace
 // prefix; the arg parameter will hold any additional caveat argument
 // text.
-type Func func(ctxt context.Context, cond, arg string) error
+type Func func(ctx context.Context, cond, arg string) error
 
 // CheckerInfo holds information on a registered checker.
 type CheckerInfo struct {
@@ -140,7 +140,7 @@ func (c *Checker) Namespace() *Namespace {
 
 // CheckFirstPartyCaveat implements bakery.FirstPartyCaveatChecker
 // by checking the caveat against all registered caveats conditions.
-func (c *Checker) CheckFirstPartyCaveat(ctxt context.Context, cav string) error {
+func (c *Checker) CheckFirstPartyCaveat(ctx context.Context, cav string) error {
 	cond, arg, err := ParseCaveat(cav)
 	if err != nil {
 		// If we can't parse it, perhaps it's in some other format,
@@ -151,7 +151,7 @@ func (c *Checker) CheckFirstPartyCaveat(ctxt context.Context, cav string) error 
 	if !ok {
 		return errgo.NoteMask(ErrCaveatNotRecognized, fmt.Sprintf("caveat %q not satisfied", cav), errgo.Any)
 	}
-	if err := cf.Check(ctxt, cond, arg); err != nil {
+	if err := cf.Check(ctx, cond, arg); err != nil {
 		return errgo.NoteMask(err, fmt.Sprintf("caveat %q not satisfied", cav), errgo.Any)
 	}
 	return nil
@@ -159,7 +159,7 @@ func (c *Checker) CheckFirstPartyCaveat(ctxt context.Context, cav string) error 
 
 var errBadCaveat = errgo.New("bad caveat")
 
-func checkError(ctxt context.Context, _, arg string) error {
+func checkError(ctx context.Context, _, arg string) error {
 	return errBadCaveat
 }
 

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -28,7 +28,7 @@ func (testClock) Now() time.Time {
 // FirstPartyCaveatChecker is declared here so we can avoid a cyclic
 // dependency on the bakery.
 type FirstPartyCaveatChecker interface {
-	CheckFirstPartyCaveat(ctxt context.Context, caveat string) error
+	CheckFirstPartyCaveat(ctx context.Context, caveat string) error
 }
 
 type checkTest struct {
@@ -71,8 +71,8 @@ var checkerTests = []struct {
 	}},
 }, {
 	about: "time from clock",
-	addContext: func(ctxt context.Context) context.Context {
-		return checkers.ContextWithClock(ctxt, testClock{})
+	addContext: func(ctx context.Context) context.Context {
+		return checkers.ContextWithClock(ctx, testClock{})
 	},
 	checks: []checkTest{{
 		caveat: checkers.TimeBeforeCaveat(now.Add(1)).Condition,
@@ -109,8 +109,8 @@ var checkerTests = []struct {
 	}},
 }, {
 	about: "declared, some entries",
-	addContext: func(ctxt context.Context) context.Context {
-		return checkers.ContextWithDeclared(ctxt, checkers.Declared{
+	addContext: func(ctx context.Context) context.Context {
+		return checkers.ContextWithDeclared(ctx, checkers.Declared{
 			Condition: "t:declared-foo",
 			Value:     "aval",
 		})
@@ -157,13 +157,13 @@ func (s *CheckersSuite) TestCheckers(c *gc.C) {
 	checkers.RegisterDeclaredCaveat(checker, "declared-foo", "testns")
 	for i, test := range checkerTests {
 		c.Logf("test %d: %s", i, test.about)
-		ctxt := context.Background()
+		ctx := context.Background()
 		if test.addContext != nil {
-			ctxt = test.addContext(ctxt)
+			ctx = test.addContext(ctx)
 		}
 		for j, check := range test.checks {
 			c.Logf("\tcheck %d", j)
-			err := checker.CheckFirstPartyCaveat(ctxt, check.caveat)
+			err := checker.CheckFirstPartyCaveat(ctx, check.caveat)
 			if check.expectError != "" {
 				c.Assert(err, gc.ErrorMatches, check.expectError)
 				if check.expectCause == nil {
@@ -323,8 +323,8 @@ func (*CheckersSuite) TestOperationsChecker(c *gc.C) {
 	checker := checkers.New(nil)
 	for i, test := range operationsCheckerTests {
 		c.Logf("%d: %s", i, test.about)
-		ctxt := checkers.ContextWithOperations(context.Background(), test.ops...)
-		err := checker.CheckFirstPartyCaveat(ctxt, test.caveat.Condition)
+		ctx := checkers.ContextWithOperations(context.Background(), test.ops...)
+		err := checker.CheckFirstPartyCaveat(ctx, test.caveat.Condition)
 		if test.expectError == "" {
 			c.Assert(err, gc.IsNil)
 			continue
@@ -408,7 +408,7 @@ func (*CheckersSuite) TestCheckerInfo(c *gc.C) {
 
 	var calledVal string
 	register := func(name, ns string) {
-		checker.Register(name, ns, func(ctxt context.Context, cond, arg string) error {
+		checker.Register(name, ns, func(ctx context.Context, cond, arg string) error {
 			calledVal = name + " " + ns
 			return nil
 		})
@@ -464,6 +464,6 @@ func (*CheckersSuite) TestCheckerInfo(c *gc.C) {
 	c.Assert(infos, jc.DeepEquals, expect)
 }
 
-func succeed(ctxt context.Context, cond, arg string) error {
+func succeed(ctx context.Context, cond, arg string) error {
 	return nil
 }

--- a/bakery/checkers/declared.go
+++ b/bakery/checkers/declared.go
@@ -36,12 +36,12 @@ type declaredKey string
 
 // ContextWithDeclared returns a context with attached declared information,
 // as returned from InferDeclared.
-func ContextWithDeclared(ctxt context.Context, declared Declared) context.Context {
-	return context.WithValue(ctxt, declaredKey(declared.Condition), declared.Value)
+func ContextWithDeclared(ctx context.Context, declared Declared) context.Context {
+	return context.WithValue(ctx, declaredKey(declared.Condition), declared.Value)
 }
 
-func declaredFromContext(ctxt context.Context, cond string) string {
-	val, _ := ctxt.Value(declaredKey(cond)).(string)
+func declaredFromContext(ctx context.Context, cond string) string {
+	val, _ := ctx.Value(declaredKey(cond)).(string)
 	return val
 }
 

--- a/bakery/checkers/operations.go
+++ b/bakery/checkers/operations.go
@@ -14,12 +14,12 @@ type opKey struct{}
 // given operations. An allow caveat will succeed only if one of the allowed
 // operations is in ops; a deny caveat will succeed only if none of the denied
 // operations are in ops.
-func ContextWithOperations(ctxt context.Context, ops ...string) context.Context {
-	return context.WithValue(ctxt, opKey{}, ops)
+func ContextWithOperations(ctx context.Context, ops ...string) context.Context {
+	return context.WithValue(ctx, opKey{}, ops)
 }
 
-func operationsFromContext(ctxt context.Context) []string {
-	ops, _ := ctxt.Value(opKey{}).([]string)
+func operationsFromContext(ctx context.Context) []string {
+	ops, _ := ctx.Value(opKey{}).([]string)
 	return ops
 }
 
@@ -51,20 +51,20 @@ func operationCaveat(cond string, op []string) Caveat {
 	return firstParty(cond, strings.Join(op, " "))
 }
 
-func checkAllow(ctxt context.Context, _, arg string) error {
-	return checkOperation(ctxt, true, arg)
+func checkAllow(ctx context.Context, _, arg string) error {
+	return checkOperation(ctx, true, arg)
 }
 
-func checkDeny(ctxt context.Context, _, arg string) error {
-	return checkOperation(ctxt, false, arg)
+func checkDeny(ctx context.Context, _, arg string) error {
+	return checkOperation(ctx, false, arg)
 }
 
 // checkOperation checks an allow or a deny caveat. The needOps
 // parameter specifies whether we require all the operations in the
 // caveat to be declared in the context.
-func checkOperation(ctxt context.Context, needOps bool, arg string) error {
-	ctxtOps := operationsFromContext(ctxt)
-	if len(ctxtOps) == 0 {
+func checkOperation(ctx context.Context, needOps bool, arg string) error {
+	ctxOps := operationsFromContext(ctx)
+	if len(ctxOps) == 0 {
 		if needOps {
 			f := strings.Fields(arg)
 			if len(f) == 0 {
@@ -76,7 +76,7 @@ func checkOperation(ctxt context.Context, needOps bool, arg string) error {
 	}
 
 	fields := strings.Fields(arg)
-	for _, op := range ctxtOps {
+	for _, op := range ctxOps {
 		if err := checkOneOp(op, needOps, fields); err != nil {
 			return errgo.Mask(err)
 		}
@@ -84,16 +84,16 @@ func checkOperation(ctxt context.Context, needOps bool, arg string) error {
 	return nil
 }
 
-func checkOneOp(ctxtOp string, needOp bool, fields []string) error {
+func checkOneOp(ctxOp string, needOp bool, fields []string) error {
 	var found bool
 	for _, op := range fields {
-		if op == ctxtOp {
+		if op == ctxOp {
 			found = true
 			break
 		}
 	}
 	if found != needOp {
-		return fmt.Errorf("%s not allowed", ctxtOp)
+		return fmt.Errorf("%s not allowed", ctxOp)
 	}
 	return nil
 }

--- a/bakery/checkers/time.go
+++ b/bakery/checkers/time.go
@@ -16,21 +16,21 @@ type Clock interface {
 
 type timeKey struct{}
 
-func ContextWithClock(ctxt context.Context, clock Clock) context.Context {
+func ContextWithClock(ctx context.Context, clock Clock) context.Context {
 	if clock == nil {
-		return ctxt
+		return ctx
 	}
-	return context.WithValue(ctxt, timeKey{}, clock)
+	return context.WithValue(ctx, timeKey{}, clock)
 }
 
-func clockFromContext(ctxt context.Context) Clock {
-	c, _ := ctxt.Value(timeKey{}).(Clock)
+func clockFromContext(ctx context.Context) Clock {
+	c, _ := ctx.Value(timeKey{}).(Clock)
 	return c
 }
 
-func checkTimeBefore(ctxt context.Context, _, arg string) error {
+func checkTimeBefore(ctx context.Context, _, arg string) error {
 	var now time.Time
-	if clock := clockFromContext(ctxt); clock != nil {
+	if clock := clockFromContext(ctx); clock != nil {
 		now = clock.Now()
 	} else {
 		now = time.Now()

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -70,7 +70,7 @@ func noDischarge(c *gc.C) func(context.Context, macaroon.Caveat, []byte) (*baker
 // own checking of declaration caveats.
 type oneIdentity struct{}
 
-func (oneIdentity) IdentityFromContext(ctxt context.Context) (bakery.Identity, []checkers.Caveat, error) {
+func (oneIdentity) IdentityFromContext(ctx context.Context) (bakery.Identity, []checkers.Caveat, error) {
 	return nil, nil, nil
 }
 
@@ -113,14 +113,14 @@ func trueCaveat(s string) checkers.Caveat {
 }
 
 // trueCheck always succeeds.
-func trueCheck(ctxt context.Context, cond, args string) error {
+func trueCheck(ctx context.Context, cond, args string) error {
 	return nil
 }
 
 // strCheck checks that the string value in the context
 // matches the argument to the condition.
-func strCheck(ctxt context.Context, cond, args string) error {
-	expect, _ := ctxt.Value(strKey{}).(string)
+func strCheck(ctx context.Context, cond, args string) error {
+	expect, _ := ctx.Value(strKey{}).(string)
 	if args != expect {
 		return fmt.Errorf("%s doesn't match %s", cond, expect)
 	}
@@ -164,12 +164,12 @@ type basicAuth struct {
 	user, password string
 }
 
-func contextWithBasicAuth(ctxt context.Context, user, password string) context.Context {
-	return context.WithValue(ctxt, basicAuthKey{}, basicAuth{user, password})
+func contextWithBasicAuth(ctx context.Context, user, password string) context.Context {
+	return context.WithValue(ctx, basicAuthKey{}, basicAuth{user, password})
 }
 
-func basicAuthFromContext(ctxt context.Context) (user, password string) {
-	auth, _ := ctxt.Value(basicAuthKey{}).(basicAuth)
+func basicAuthFromContext(ctx context.Context) (user, password string) {
+	auth, _ := ctx.Value(basicAuthKey{}).(basicAuth)
 	return auth.user, auth.password
 }
 

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -37,7 +37,7 @@ func DischargeAll(
 // When localKey is nil, DischargeAllWithKey is exactly the same as
 // DischargeAll.
 func DischargeAllWithKey(
-	ctxt context.Context,
+	ctx context.Context,
 	m *Macaroon,
 	getDischarge func(ctx context.Context, cav macaroon.Caveat, encodedCaveat []byte) (*Macaroon, error),
 	localKey *KeyPair,
@@ -73,7 +73,7 @@ func DischargeAllWithKey(
 		var err error
 		if localKey != nil && cav.cav.Location == "local" {
 			// TODO use a small caveat id.
-			dm, err = Discharge(ctxt, DischargeParams{
+			dm, err = Discharge(ctx, DischargeParams{
 				Key:     localKey,
 				Checker: localDischargeChecker,
 				Caveat:  cav.encryptedCaveat,
@@ -81,7 +81,7 @@ func DischargeAllWithKey(
 				Locator: emptyLocator{},
 			})
 		} else {
-			dm, err = getDischarge(ctxt, cav.cav, cav.encryptedCaveat)
+			dm, err = getDischarge(ctx, cav.cav, cav.encryptedCaveat)
 		}
 		if err != nil {
 			return nil, errgo.NoteMask(err, fmt.Sprintf("cannot get discharge from %q", cav.cav.Location), errgo.Any)

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -54,8 +54,8 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 }
 
 func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Request) {
-	ctxt := checkers.ContextWithOperations(context.TODO(), "gold")
-	if _, _, err := httpbakery.CheckRequest(ctxt, srv.svc, req, nil); err != nil {
+	ctx := checkers.ContextWithOperations(context.TODO(), "gold")
+	if _, _, err := httpbakery.CheckRequest(ctx, srv.svc, req, nil); err != nil {
 		srv.writeError(w, req, "gold", err)
 		return
 	}
@@ -63,8 +63,8 @@ func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Requ
 }
 
 func (srv *targetServiceHandler) serveSilver(w http.ResponseWriter, req *http.Request) {
-	ctxt := checkers.ContextWithOperations(context.TODO(), "silver")
-	if _, _, err := httpbakery.CheckRequest(ctxt, srv.svc, req, nil); err != nil {
+	ctx := checkers.ContextWithOperations(context.TODO(), "silver")
+	if _, _, err := httpbakery.CheckRequest(ctx, srv.svc, req, nil); err != nil {
 		srv.writeError(w, req, "silver", err)
 		return
 	}

--- a/bakery/identity.go
+++ b/bakery/identity.go
@@ -21,7 +21,7 @@ type IdentityClient interface {
 	// (for example because of a database access error) - it's
 	// OK to return all zero values when there's
 	// no identity found and no third party to address caveats to.
-	IdentityFromContext(ctxt context.Context) (Identity, []checkers.Caveat, error)
+	IdentityFromContext(ctx context.Context) (Identity, []checkers.Caveat, error)
 
 	// DeclarationCaveat returns the caveat that is used to declare
 	// the identity. By convention, the condition should have no argument.
@@ -56,7 +56,7 @@ type noIdentities struct{}
 
 // IdentityFromContext implements IdentityClient.IdentityFromContext by
 // never returning a declared identity or any caveats.
-func (noIdentities) IdentityFromContext(ctxt context.Context) (Identity, []checkers.Caveat, error) {
+func (noIdentities) IdentityFromContext(ctx context.Context) (Identity, []checkers.Caveat, error) {
 	return nil, nil, nil
 }
 
@@ -92,7 +92,7 @@ func (id SimpleIdentity) Id() string {
 // Allow implements ACLIdentity by allowing the identity access to
 // ACL members that are equal to id. That is, some user u is considered
 // a member of group u and no other.
-func (id SimpleIdentity) Allow(ctxt context.Context, acl []string) (bool, error) {
+func (id SimpleIdentity) Allow(ctx context.Context, acl []string) (bool, error) {
 	for _, g := range acl {
 		if string(id) == g {
 			return true, nil

--- a/bakery/keys.go
+++ b/bakery/keys.go
@@ -95,7 +95,7 @@ type ThirdPartyInfo struct {
 type ThirdPartyLocator interface {
 	// ThirdPartyInfo returns information on the third
 	// party at the given location. It returns ErrNotFound if no match is found.
-	ThirdPartyInfo(ctxt context.Context, loc string) (ThirdPartyInfo, error)
+	ThirdPartyInfo(ctx context.Context, loc string) (ThirdPartyInfo, error)
 }
 
 // ThirdPartyLocatorMap implements a simple ThirdPartyLocator.
@@ -123,7 +123,7 @@ func canonicalLocation(loc string) string {
 }
 
 // ThirdPartyInfo implements the ThirdPartyLocator interface.
-func (s *ThirdPartyStore) ThirdPartyInfo(ctxt context.Context, loc string) (ThirdPartyInfo, error) {
+func (s *ThirdPartyStore) ThirdPartyInfo(ctx context.Context, loc string) (ThirdPartyInfo, error) {
 	if info, ok := s.m[canonicalLocation(loc)]; ok {
 		return info, nil
 	}

--- a/bakery/mgorootkeystore/rootkey.go
+++ b/bakery/mgorootkeystore/rootkey.go
@@ -218,7 +218,7 @@ type store struct {
 }
 
 // Get implements bakery.RootKeyStore.Get.
-func (s *store) Get(ctxt context.Context, id []byte) ([]byte, error) {
+func (s *store) Get(ctx context.Context, id []byte) ([]byte, error) {
 	s.keys.mu.Lock()
 	defer s.keys.mu.Unlock()
 

--- a/bakery/service_test.go
+++ b/bakery/service_test.go
@@ -219,8 +219,8 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 
 	// Make sure the macaroons actually check out correctly
 	// when provided with the declared checker.
-	ctxt := checkers.ContextWithDeclared(testContext, declared)
-	_, err = firstParty.Checker.Auth(d).Allow(ctxt, bakery.LoginOp)
+	ctx := checkers.ContextWithDeclared(testContext, declared)
+	_, err = firstParty.Checker.Auth(d).Allow(ctx, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 
 	// Try again when the third party does add a required declaration.
@@ -241,8 +241,8 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 		Value:     "foo a",
 	})
 
-	ctxt = checkers.ContextWithDeclared(testContext, declared)
-	_, err = firstParty.Checker.Auth(d).Allow(ctxt, bakery.LoginOp)
+	ctx = checkers.ContextWithDeclared(testContext, declared)
+	_, err = firstParty.Checker.Auth(d).Allow(ctx, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 
 	// Try again, but this time pretend a client is sneakily trying
@@ -268,7 +268,7 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 		Condition: "declared",
 	})
 
-	ctxt = checkers.ContextWithDeclared(testContext, declared)
+	ctx = checkers.ContextWithDeclared(testContext, declared)
 	_, err = firstParty.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
 	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo a" not satisfied: got "foo a", expected ""`)
 }

--- a/bakery/store.go
+++ b/bakery/store.go
@@ -12,7 +12,7 @@ import (
 type RootKeyStore interface {
 	// Get returns the root key for the given id.
 	// If the item is not there, it returns ErrNotFound.
-	Get(ctxt context.Context, id []byte) ([]byte, error)
+	Get(ctx context.Context, id []byte) ([]byte, error)
 
 	// RootKey returns the root key to be used for making a new
 	// macaroon, and an id that can be used to look it up later with
@@ -24,7 +24,7 @@ type RootKeyStore interface {
 	// Note that there is no need for it to return a new root key
 	// for every call - keys may be reused, although some key
 	// cycling is over time is advisable.
-	RootKey(ctxt context.Context) (rootKey []byte, id []byte, err error)
+	RootKey(ctx context.Context) (rootKey []byte, id []byte, err error)
 }
 
 // NewMemRootKeyStore returns an implementation of
@@ -78,7 +78,7 @@ type MacaroonOpStore interface {
 	// because the macaroon signature failed or the root key
 	// was not found - any other error will be treated as fatal
 	// by Checker and cause authorization to terminate.
-	MacaroonOps(ctxt context.Context, ms macaroon.Slice) ([]Op, []string, error)
+	MacaroonOps(ctx context.Context, ms macaroon.Slice) ([]Op, []string, error)
 }
 
 // OpsStore defines a persistent store for operation sets
@@ -99,7 +99,7 @@ type OpsStore interface {
 	//
 	// Implementations may assume that the operations
 	// are in canonical order and contain no duplicates.
-	PutOps(ctxt context.Context, key string, ops []Op, expiry time.Time) error
+	PutOps(ctx context.Context, key string, ops []Op, expiry time.Time) error
 
 	// GetOps returns the set of operations for a given key.
 	// If the key was not found, it should return an error with an
@@ -112,7 +112,7 @@ type OpsStore interface {
 	// whole set of operations. Then an implementation
 	// might be able to scale more easily to large sets of
 	// operations, for example by using a bloom filter.
-	GetOps(ctxt context.Context, key string) ([]Op, error)
+	GetOps(ctx context.Context, key string) ([]Op, error)
 }
 
 type memOpsStore struct {

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -151,7 +151,7 @@ func (d *Discharger) Location() string {
 }
 
 // PublicKeyForLocation implements bakery.PublicKeyLocator.
-func (d *Discharger) ThirdPartyInfo(ctxt context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+func (d *Discharger) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
 	if loc == d.Location() {
 		return bakery.ThirdPartyInfo{
 			PublicKey: d.Key.Public,
@@ -268,7 +268,7 @@ func (d *InteractiveDischarger) SetChecker(c httpbakery.ThirdPartyCaveatChecker)
 
 // CheckThirdPartyCaveat implements httpbakery.ThirdPartyCaveatDischarger
 // by always returning an interaction-required error.
-func (d *InteractiveDischarger) CheckThirdPartyCaveat(ctxt context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+func (d *InteractiveDischarger) CheckThirdPartyCaveat(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
 	d.mu.Lock()
 	id := fmt.Sprintf("%d", d.id)
 	d.id++

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -258,7 +258,7 @@ type recordingChecker struct {
 	caveats []string
 }
 
-func (c *recordingChecker) CheckFirstPartyCaveat(ctxt context.Context, caveat string) error {
+func (c *recordingChecker) CheckFirstPartyCaveat(ctx context.Context, caveat string) error {
 	c.caveats = append(c.caveats, caveat)
 	return nil
 }

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -456,7 +456,7 @@ type idmClient struct {
 	dischargerURL string
 }
 
-func (c idmClient) IdentityFromContext(ctxt context.Context) (bakery.Identity, []checkers.Caveat, error) {
+func (c idmClient) IdentityFromContext(ctx context.Context) (bakery.Identity, []checkers.Caveat, error) {
 	return nil, identityCaveats(c.dischargerURL), nil
 }
 

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -15,12 +15,12 @@ type httpRequestKey struct{}
 // ContextWithRequest returns the context with information from the
 // given request attached as context.  This is used by the httpbakery
 // checkers (see RegisterCheckers for details).
-func ContextWithRequest(ctxt context.Context, req *http.Request) context.Context {
-	return context.WithValue(ctxt, httpRequestKey{}, req)
+func ContextWithRequest(ctx context.Context, req *http.Request) context.Context {
+	return context.WithValue(ctx, httpRequestKey{}, req)
 }
 
-func requestFromContext(ctxt context.Context) *http.Request {
-	req, _ := ctxt.Value(httpRequestKey{}).(*http.Request)
+func requestFromContext(ctx context.Context) *http.Request {
+	req, _ := ctx.Value(httpRequestKey{}).(*http.Request)
 	return req
 }
 
@@ -72,8 +72,8 @@ func NewChecker() *checkers.Checker {
 
 // ipAddrCheck implements the IP client address checker
 // for an HTTP request.
-func ipAddrCheck(ctxt context.Context, cond, args string) error {
-	req := requestFromContext(ctxt)
+func ipAddrCheck(ctx context.Context, cond, args string) error {
+	req := requestFromContext(ctx)
 	if req == nil {
 		return errgo.Newf("no IP address found in context")
 	}
@@ -96,8 +96,8 @@ func ipAddrCheck(ctxt context.Context, cond, args string) error {
 
 // clientOriginCheck implements the Origin header checker
 // for an HTTP request.
-func clientOriginCheck(ctxt context.Context, cond, args string) error {
-	req := requestFromContext(ctxt)
+func clientOriginCheck(ctx context.Context, cond, args string) error {
+	req := requestFromContext(ctx)
 	if req == nil {
 		return errgo.Newf("no origin found in context")
 	}

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -158,11 +158,11 @@ func (s *CheckersSuite) TestCheckers(c *gc.C) {
 	checker := httpbakery.NewChecker()
 	for i, test := range checkerTests {
 		c.Logf("test %d: %s", i, test.about)
-		ctxt := httpbakery.ContextWithRequest(testContext, test.req)
+		ctx := httpbakery.ContextWithRequest(testContext, test.req)
 		for j, check := range test.checks {
 			c.Logf("\tcheck %d", j)
 
-			err := checker.CheckFirstPartyCaveat(ctxt, checker.Namespace().ResolveCaveat(check.caveat).Condition)
+			err := checker.CheckFirstPartyCaveat(ctx, checker.Namespace().ResolveCaveat(check.caveat).Condition)
 			if check.expectError != "" {
 				c.Assert(err, gc.ErrorMatches, check.expectError)
 				if check.expectCause == nil {

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -544,7 +544,7 @@ func (s *ClientSuite) TestMacaroonCookieName(c *gc.C) {
 	checked := make(map[string]bool)
 	checker := checkers.New(nil)
 	checker.Namespace().Register("testns", "")
-	checker.Register("once", "testns", func(ctxt context.Context, _, arg string) error {
+	checker.Register("once", "testns", func(ctx context.Context, _, arg string) error {
 		if checked[arg] {
 			return errgo.Newf("caveat %q has already been checked once", arg)
 		}
@@ -1297,7 +1297,7 @@ func isSomethingCaveat() checkers.Caveat {
 	}
 }
 
-func checkIsSomething(ctxt context.Context, _, arg string) error {
+func checkIsSomething(ctx context.Context, _, arg string) error {
 	if arg != "something" {
 		return fmt.Errorf(`%v doesn't match "something"`, arg)
 	}

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -31,7 +31,7 @@ type ThirdPartyCaveatChecker interface {
 	// Note than when used in the context of a discharge handler
 	// created by Discharger, any returned errors will be marshaled
 	// as documented in DischargeHandler.ErrorMapper.
-	CheckThirdPartyCaveat(ctxt context.Context, req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
+	CheckThirdPartyCaveat(ctx context.Context, req *http.Request, info *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error)
 }
 
 // ThirdPartyCaveatCheckerFunc implements ThirdPartyCaveatChecker
@@ -127,7 +127,7 @@ func NewDischarger(p DischargerParams) *Discharger {
 
 type emptyLocator struct{}
 
-func (emptyLocator) ThirdPartyInfo(ctxt context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+func (emptyLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
 	return bakery.ThirdPartyInfo{}, bakery.ErrNotFound
 }
 

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -348,8 +348,8 @@ type testLocator struct {
 	locator bakery.ThirdPartyLocator
 }
 
-func (l testLocator) ThirdPartyInfo(ctxt context.Context, loc string) (bakery.ThirdPartyInfo, error) {
-	return l.locator.ThirdPartyInfo(ctxt, l.loc)
+func (l testLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+	return l.locator.ThirdPartyInfo(ctx, l.loc)
 }
 
 type titleTestFiller struct {


### PR DESCRIPTION
Everywhere in the stdlib and in our other repositories uses
ctx, so let's use it here.

This is an entirely mechanical change.
