### PR TITLE
bakery: revert declaration simplification

### DIFF
--- a/bakery/checkers/checkers.go
+++ b/bakery/checkers/checkers.go
@@ -18,6 +18,7 @@ const StdNamespace = "std"
 // First and third party caveat conditions are both defined here,
 // even though notionally they exist in separate name spaces.
 const (
+	CondDeclared   = "declared"
 	CondTimeBefore = "time-before"
 	CondError      = "error"
 	CondAllow      = "allow"
@@ -25,7 +26,6 @@ const (
 )
 
 const (
-	// TODO(rog) remove this.
 	CondNeedDeclared = "need-declared"
 )
 
@@ -50,6 +50,7 @@ type CheckerInfo struct {
 
 var allCheckers = map[string]Func{
 	CondTimeBefore: checkTimeBefore,
+	CondDeclared:   checkDeclared,
 	CondAllow:      checkAllow,
 	CondDeny:       checkDeny,
 	CondError:      checkError,

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -1,12 +1,14 @@
 package checkers_test
 
 import (
+	"fmt"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
@@ -100,29 +102,42 @@ var checkerTests = []struct {
 }, {
 	about: "declared, no entries",
 	checks: []checkTest{{
-		caveat:      "t:declared-foo aval",
-		expectError: `caveat "t:declared-foo aval" not satisfied: got "aval", expected ""`,
+		caveat:      checkers.DeclaredCaveat("a", "aval").Condition,
+		expectError: `caveat "declared a aval" not satisfied: got a=null, expected "aval"`,
 	}, {
-		caveat: "t:declared-foo",
-	}, {
-		caveat: "t:declared-foo ",
+		caveat:      checkers.CondDeclared,
+		expectError: `caveat "declared" not satisfied: declared caveat has no value`,
 	}},
 }, {
 	about: "declared, some entries",
 	addContext: func(ctx context.Context) context.Context {
-		return checkers.ContextWithDeclared(ctx, checkers.Declared{
-			Condition: "t:declared-foo",
-			Value:     "aval",
+		return checkers.ContextWithDeclared(ctx, map[string]string{
+			"a":   "aval",
+			"b":   "bval",
+			"spc": " a b",
 		})
 	},
 	checks: []checkTest{{
-		caveat: "t:declared-foo aval",
+		caveat: checkers.DeclaredCaveat("a", "aval").Condition,
 	}, {
-		caveat:      "t:declared-foo bval",
-		expectError: `caveat "t:declared-foo bval" not satisfied: got "bval", expected "aval"`,
+		caveat: checkers.DeclaredCaveat("b", "bval").Condition,
 	}, {
-		caveat:      "t:declared-foo  aval",
-		expectError: `caveat "t:declared-foo  aval" not satisfied: got " aval", expected "aval"`,
+		caveat: checkers.DeclaredCaveat("spc", " a b").Condition,
+	}, {
+		caveat:      checkers.DeclaredCaveat("a", "bval").Condition,
+		expectError: `caveat "declared a bval" not satisfied: got a="aval", expected "bval"`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("a", " aval").Condition,
+		expectError: `caveat "declared a  aval" not satisfied: got a="aval", expected " aval"`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("spc", "a b").Condition,
+		expectError: `caveat "declared spc a b" not satisfied: got spc=" a b", expected "a b"`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("", "a b").Condition,
+		expectError: `caveat "error invalid caveat 'declared' key \\"\\"" not satisfied: bad caveat`,
+	}, {
+		caveat:      checkers.DeclaredCaveat("a b", "a b").Condition,
+		expectError: `caveat "error invalid caveat 'declared' key \\"a b\\"" not satisfied: bad caveat`,
 	}},
 }, {
 	about: "error caveat",
@@ -154,7 +169,6 @@ func (s *CheckersSuite) TestCheckers(c *gc.C) {
 	checker.Namespace().Register("testns", "t")
 	checker.Register("a", "testns", argChecker(c, "t:a", "aval"))
 	checker.Register("b", "testns", argChecker(c, "t:b", "bval"))
-	checkers.RegisterDeclaredCaveat(checker, "declared-foo", "testns")
 	for i, test := range checkerTests {
 		c.Logf("test %d: %s", i, test.about)
 		ctx := context.Background()
@@ -178,103 +192,157 @@ func (s *CheckersSuite) TestCheckers(c *gc.C) {
 }
 
 var inferDeclaredTests = []struct {
-	about      string
-	declCond   string
-	conditions []string
-	expect     checkers.Declared
+	about     string
+	caveats   [][]checkers.Caveat
+	expect    map[string]string
+	namespace map[string]string
 }{{
-	about:    "no conditions",
-	declCond: "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
+	about:  "no macaroons",
+	expect: map[string]string{},
+}, {
+	about: "single macaroon with one declaration",
+	caveats: [][]checkers.Caveat{{{
+		Condition: "declared foo bar",
+	}}},
+	expect: map[string]string{
+		"foo": "bar",
 	},
 }, {
-	about:      "single macaroon with one declaration, empty prefix",
-	conditions: []string{"declared-foo bar"},
-	declCond:   "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-		Value:     "bar",
+	about: "only one argument to declared",
+	caveats: [][]checkers.Caveat{{{
+		Condition: "declared foo",
+	}}},
+	expect: map[string]string{},
+}, {
+	about: "spaces in value",
+	caveats: [][]checkers.Caveat{{{
+		Condition: "declared foo bar bloggs",
+	}}},
+	expect: map[string]string{
+		"foo": "bar bloggs",
 	},
 }, {
-	about:      "spaces in value",
-	conditions: []string{"declared-foo foo bar"},
-	declCond:   "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-		Value:     "foo bar",
-	},
+	about: "attribute with declared prefix",
+	caveats: [][]checkers.Caveat{{{
+		Condition: "declaredccf foo",
+	}}},
+	expect: map[string]string{},
 }, {
-	about:      "condition with declared prefix",
-	declCond:   "declared-foo",
-	conditions: []string{"declared-fooccf foo"},
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-	},
-}, {
-	about:      "condition with no arguments",
-	declCond:   "declared-foo",
-	conditions: []string{"declared-fooccf foo"},
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-	},
-}, {
-	about: "several different caveats",
-	conditions: []string{
-		"declared-foo a",
-		"bar b",
-		"x y",
-	},
-	declCond: "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-		Value:     "a",
+	about: "several macaroons with different declares",
+	caveats: [][]checkers.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: map[string]string{
+		"a": "aval",
+		"b": "bval",
+		"c": "cval",
+		"d": "dval",
 	},
 }, {
 	about: "duplicate values",
-	conditions: []string{
-		"declared-foo a",
-		"declared-foo a",
-	},
-	declCond: "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
-		Value:     "a",
-	},
-}, {
-	about: "one empty, one not",
-	conditions: []string{
-		"declared-foo aval",
-		"declared-foo",
-	},
-	declCond: "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
+	caveats: [][]checkers.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("b", "bval"),
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: map[string]string{
+		"a": "aval",
+		"b": "bval",
+		"c": "cval",
+		"d": "dval",
 	},
 }, {
 	about: "conflicting values",
-	conditions: []string{
-		"declared-foo aval",
-		"declared-foo bval",
-	},
-	declCond: "declared-foo",
-	expect: checkers.Declared{
-		Condition: "declared-foo",
+	caveats: [][]checkers.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		checkers.DeclaredCaveat("a", "conflict"),
+		checkers.DeclaredCaveat("b", "bval"),
+	}, {
+		checkers.DeclaredCaveat("a", "conflict"),
+		checkers.DeclaredCaveat("b", "another conflict"),
+		checkers.DeclaredCaveat("c", "cval"),
+		checkers.DeclaredCaveat("d", "dval"),
+	}},
+	expect: map[string]string{
+		"c": "cval",
+		"d": "dval",
 	},
 }, {
-	about:      "unparseable caveats ignored",
-	conditions: []string{" bad", "a aval"},
-	declCond:   "a",
-	expect: checkers.Declared{
-		Condition: "a",
-		Value:     "aval",
+	about: "third party caveats ignored",
+	caveats: [][]checkers.Caveat{{{
+		Condition: "declared a no conflict",
+		Location:  "location",
+	},
+		checkers.DeclaredCaveat("a", "aval"),
+	}},
+	expect: map[string]string{
+		"a": "aval",
+	},
+}, {
+	about: "unparseable caveats ignored",
+	caveats: [][]checkers.Caveat{{{
+		Condition: " bad",
+	},
+		checkers.DeclaredCaveat("a", "aval"),
+	}},
+	expect: map[string]string{
+		"a": "aval",
+	},
+}, {
+	about: "infer with namespace",
+	namespace: map[string]string{
+		checkers.StdNamespace: "",
+		"testns":              "t",
+	},
+	caveats: [][]checkers.Caveat{{
+		checkers.DeclaredCaveat("a", "aval"),
+		// A declared caveat from a different namespace doesn't
+		// interfere.
+		caveatWithNamespace(checkers.DeclaredCaveat("a", "bval"), "testns"),
+	}},
+	expect: map[string]string{
+		"a": "aval",
 	},
 }}
 
+func caveatWithNamespace(cav checkers.Caveat, uri string) checkers.Caveat {
+	cav.Namespace = uri
+	return cav
+}
+
 func (*CheckersSuite) TestInferDeclared(c *gc.C) {
 	for i, test := range inferDeclaredTests {
+		if test.namespace == nil {
+			test.namespace = map[string]string{
+				checkers.StdNamespace: "",
+			}
+		}
+		ns := checkers.NewNamespace(test.namespace)
 		c.Logf("test %d: %s", i, test.about)
-		c.Assert(checkers.InferDeclared(test.declCond, test.conditions), gc.Equals, test.expect)
+		ms := make(macaroon.Slice, len(test.caveats))
+		for i, caveats := range test.caveats {
+			m, err := macaroon.New(nil, []byte(fmt.Sprint(i)), "", macaroon.LatestVersion)
+			c.Assert(err, gc.IsNil)
+			for _, cav := range caveats {
+				cav = ns.ResolveCaveat(cav)
+				if cav.Location == "" {
+					m.AddFirstPartyCaveat(cav.Condition)
+				} else {
+					m.AddThirdPartyCaveat(nil, []byte(cav.Condition), cav.Location)
+				}
+			}
+			ms[i] = m
+		}
+		c.Assert(checkers.InferDeclared(nil, ms), jc.DeepEquals, test.expect)
 	}
 }
 

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -30,7 +30,6 @@ var testChecker = func() *checkers.Checker {
 	c.Namespace().Register("testns", "")
 	c.Register("str", "testns", strCheck)
 	c.Register("true", "testns", trueCheck)
-	checkers.RegisterDeclaredCaveat(c, "declared", checkers.StdNamespace)
 	return c
 }()
 
@@ -74,11 +73,7 @@ func (oneIdentity) IdentityFromContext(ctx context.Context) (bakery.Identity, []
 	return nil, nil, nil
 }
 
-func (oneIdentity) DeclarationCaveat() checkers.Caveat {
-	return checkers.Caveat{}
-}
-
-func (oneIdentity) DeclaredIdentity(string) (bakery.Identity, error) {
+func (oneIdentity) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
 	return noone{}, nil
 }
 

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -188,19 +188,20 @@ func discharge(ctx context.Context, oven *bakery.Oven, checker bakery.ThirdParty
 	})
 }
 
-func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
+func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 	locator := bakery.NewThirdPartyStore()
 	firstParty := newBakery("first", locator)
 	thirdParty := newBakery("third", locator)
 
-	// firstParty mints a V2 macaroon with a third-party caveat addressed
+	// firstParty mints a macaroon with a third-party caveat addressed
 	// to thirdParty with a need-declared caveat.
-	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.Version2, ages, []checkers.Caveat{
+	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
 		checkers.NeedDeclaredCaveat(checkers.Caveat{
 			Location:  "third",
 			Condition: "something",
-		}, "foo"),
+		}, "foo", "bar"),
 	}, bakery.LoginOp)
+
 	c.Assert(err, gc.IsNil)
 
 	// The client asks for a discharge macaroon for each third party caveat.
@@ -209,12 +210,12 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	// The required declared attribute should have been added
+	// The required declared attributes should have been added
 	// to the discharge macaroons.
-	declared := checkers.InferDeclared("declared", firstPartyCaveatConditions(d))
-	c.Assert(declared, jc.DeepEquals, checkers.Declared{
-		Condition: "declared",
-		Value:     "foo",
+	declared := checkers.InferDeclared(firstParty.Checker.Namespace(), d)
+	c.Assert(declared, gc.DeepEquals, map[string]string{
+		"foo": "",
+		"bar": "",
 	})
 
 	// Make sure the macaroons actually check out correctly
@@ -228,17 +229,19 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 	// The client asks for a discharge macaroon for each third party caveat.
 	d, err = bakery.DischargeAll(testContext, m, func(ctx context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
 		checker := thirdPartyCheckerWithCaveats{
-			preV3DeclaredCaveat("foo", "a"),
+			checkers.DeclaredCaveat("foo", "a"),
+			checkers.DeclaredCaveat("arble", "b"),
 		}
 		return discharge(ctx, thirdParty.Oven, checker, cav, payload)
 	})
 	c.Assert(err, gc.IsNil)
 
 	// One attribute should have been added, the other was already there.
-	declared = checkers.InferDeclared("declared", firstPartyCaveatConditions(d))
-	c.Assert(declared, jc.DeepEquals, checkers.Declared{
-		Condition: "declared",
-		Value:     "foo a",
+	declared = checkers.InferDeclared(firstParty.Checker.Namespace(), d)
+	c.Assert(declared, gc.DeepEquals, map[string]string{
+		"foo":   "a",
+		"bar":   "",
+		"arble": "b",
 	})
 
 	ctx = checkers.ContextWithDeclared(testContext, declared)
@@ -249,28 +252,101 @@ func (s *ServiceSuite) TestNeedDeclaredPreV3(c *gc.C) {
 	// to add another "declared" attribute to alter the declarations.
 	d, err = bakery.DischargeAll(testContext, m, func(ctx context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
 		checker := thirdPartyCheckerWithCaveats{
-			preV3DeclaredCaveat("foo", "a"),
+			checkers.DeclaredCaveat("foo", "a"),
+			checkers.DeclaredCaveat("arble", "b"),
 		}
 
 		// Sneaky client adds a first party caveat.
 		m, err := discharge(ctx, thirdParty.Oven, checker, cav, payload)
 		c.Assert(err, gc.IsNil)
 
-		err = m.AddCaveat(ctx, preV3DeclaredCaveat("foo", "c"), nil, nil)
+		err = m.AddCaveat(ctx, checkers.DeclaredCaveat("foo", "c"), nil, nil)
 		c.Assert(err, gc.IsNil)
 		return m, nil
 	})
 
 	c.Assert(err, gc.IsNil)
 
-	declared = checkers.InferDeclared("declared", firstPartyCaveatConditions(d))
-	c.Assert(declared, gc.DeepEquals, checkers.Declared{
-		Condition: "declared",
+	declared = checkers.InferDeclared(firstParty.Checker.Namespace(), d)
+	c.Assert(declared, gc.DeepEquals, map[string]string{
+		"bar":   "",
+		"arble": "b",
 	})
 
 	ctx = checkers.ContextWithDeclared(testContext, declared)
 	_, err = firstParty.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
-	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo a" not satisfied: got "foo a", expected ""`)
+	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo a" not satisfied: got foo=null, expected "a"`)
+}
+
+func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
+	locator := bakery.NewThirdPartyStore()
+	firstParty := newBakery("first", locator)
+	thirdParty := newBakery("third", locator)
+
+	// firstParty mints a macaroon with two third party caveats
+	// with overlapping attributes.
+	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
+		checkers.NeedDeclaredCaveat(checkers.Caveat{
+			Location:  "third",
+			Condition: "x",
+		}, "foo", "bar"),
+		checkers.NeedDeclaredCaveat(checkers.Caveat{
+			Location:  "third",
+			Condition: "y",
+		}, "bar", "baz"),
+	}, bakery.LoginOp)
+
+	c.Assert(err, gc.IsNil)
+
+	// The client asks for a discharge macaroon for each third party caveat.
+	// Since no declarations are added by the discharger,
+	d, err := bakery.DischargeAll(testContext, m, func(ctx context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
+		return discharge(ctx, thirdParty.Oven, bakery.ThirdPartyCaveatCheckerFunc(func(context.Context, *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+			return nil, nil
+		}), cav, payload)
+
+	})
+	c.Assert(err, gc.IsNil)
+	declared := checkers.InferDeclared(firstParty.Checker.Namespace(), d)
+	c.Assert(declared, gc.DeepEquals, map[string]string{
+		"foo": "",
+		"bar": "",
+		"baz": "",
+	})
+	ctx := checkers.ContextWithDeclared(testContext, declared)
+	_, err = firstParty.Checker.Auth(d).Allow(ctx, bakery.LoginOp)
+	c.Assert(err, gc.IsNil)
+
+	// If they return conflicting values, the discharge fails.
+	// The client asks for a discharge macaroon for each third party caveat.
+	// Since no declarations are added by the discharger,
+	d, err = bakery.DischargeAll(testContext, m, func(ctx context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
+		return discharge(ctx, thirdParty.Oven, bakery.ThirdPartyCaveatCheckerFunc(func(_ context.Context, cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+			switch string(cavInfo.Condition) {
+			case "x":
+				return []checkers.Caveat{
+					checkers.DeclaredCaveat("foo", "fooval1"),
+				}, nil
+			case "y":
+				return []checkers.Caveat{
+					checkers.DeclaredCaveat("foo", "fooval2"),
+					checkers.DeclaredCaveat("baz", "bazval"),
+				}, nil
+			}
+			return nil, fmt.Errorf("not matched")
+		}), cav, payload)
+
+	})
+
+	c.Assert(err, gc.IsNil)
+	declared = checkers.InferDeclared(firstParty.Checker.Namespace(), d)
+	c.Assert(declared, gc.DeepEquals, map[string]string{
+		"bar": "",
+		"baz": "bazval",
+	})
+	ctx = checkers.ContextWithDeclared(testContext, declared)
+	_, err = firstParty.Checker.Auth(d).Allow(testContext, bakery.LoginOp)
+	c.Assert(err, gc.ErrorMatches, `cannot authorize login macaroon: caveat "declared foo fooval1" not satisfied: got foo=null, expected "fooval1"`)
 }
 
 func (s *ServiceSuite) TestDischargeMacaroonCannotBeUsedAsNormalMacaroon(c *gc.C) {
@@ -347,16 +423,4 @@ func (s *ServiceSuite) TestThirdPartyDischargeMacaroonIdsAreSmall(c *gc.C) {
 			}
 		}
 	}
-}
-
-func firstPartyCaveatConditions(ms macaroon.Slice) []string {
-	var conds []string
-	for _, m := range ms {
-		for _, cav := range m.Caveats() {
-			if cav.VerificationId == nil {
-				conds = append(conds, string(cav.Id))
-			}
-		}
-	}
-	return conds
 }

--- a/bakery/identity.go
+++ b/bakery/identity.go
@@ -23,17 +23,10 @@ type IdentityClient interface {
 	// no identity found and no third party to address caveats to.
 	IdentityFromContext(ctx context.Context) (Identity, []checkers.Caveat, error)
 
-	// DeclarationCaveat returns the caveat that is used to declare
-	// the identity. By convention, the condition should have no argument.
-	// Implementations that do not support declaration caveats
-	// may return the zero caveat.
-	DeclarationCaveat() checkers.Caveat
-
 	// DeclaredIdentity parses the identity declaration from the given
-	// declared value, which is taken from the caveats matching the
-	// value returned from DeclarationCaveat. If any of them hold
-	// different values, this method will not be invoked.
-	DeclaredIdentity(declaredValue string) (Identity, error)
+	// declared attributes.
+	// TODO take the set of first party caveat conditions instead?
+	DeclaredIdentity(declared map[string]string) (Identity, error)
 }
 
 // Identity holds identity information declared in a first party caveat
@@ -60,15 +53,9 @@ func (noIdentities) IdentityFromContext(ctx context.Context) (Identity, []checke
 	return nil, nil, nil
 }
 
-// DeclarationCaveat implements IdentityClient.DeclarationCaveat
-// by returning the empty caveat.
-func (noIdentities) DeclarationCaveat() checkers.Caveat {
-	return checkers.Caveat{}
-}
-
 // DeclaredIdentity implements IdentityClient.DeclaredIdentity by
 // always returning an error.
-func (noIdentities) DeclaredIdentity(string) (Identity, error) {
+func (noIdentities) DeclaredIdentity(declared map[string]string) (Identity, error) {
 	return nil, errgo.Newf("no identity declared or possible")
 }
 

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -29,8 +29,6 @@ type agentSuite struct {
 	handle      func(ctx context.Context, w http.ResponseWriter, req *http.Request)
 }
 
-const agentTestNamespace = "testagent"
-
 var _ = gc.Suite(&agentSuite{})
 
 func (s *agentSuite) SetUpTest(c *gc.C) {
@@ -39,7 +37,6 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	key, err := bakery.GenerateKey()
 	c.Assert(err, gc.IsNil)
 	s.agentBakery = bakery.New(bakery.BakeryParams{
-		Checker:        newChecker(),
 		IdentityClient: idmClient{s.discharger.Location()},
 		Key:            key,
 	})
@@ -47,7 +44,6 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	key, err = bakery.GenerateKey()
 	c.Assert(err, gc.IsNil)
 	s.bakery = bakery.New(bakery.BakeryParams{
-		Checker:        newChecker(),
 		Locator:        s.discharger,
 		IdentityClient: idmClient{s.discharger.Location()},
 		Key:            key,
@@ -467,15 +463,8 @@ func identityCaveats(dischargerURL string) []checkers.Caveat {
 	}}
 }
 
-func (c idmClient) DeclarationCaveat() checkers.Caveat {
-	return checkers.Caveat{
-		Condition: "declared-username",
-		Namespace: agentTestNamespace,
-	}
-}
-
-func (c idmClient) DeclaredIdentity(user string) (bakery.Identity, error) {
-	return bakery.SimpleIdentity(user), nil
+func (c idmClient) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+	return bakery.SimpleIdentity(declared["username"]), nil
 }
 
 func mustParseURL(s string) *url.URL {
@@ -520,7 +509,7 @@ func (s *agentSuite) defaultHandle(ctx context.Context, w http.ResponseWriter, r
 	_, authErr := s.agentBakery.Checker.Auth(httpbakery.RequestMacaroons(req)...).Allow(ctx, bakery.LoginOp)
 	if authErr == nil {
 		cavs := []checkers.Caveat{
-			declaredUsernameCaveat(username),
+			checkers.DeclaredCaveat("username", username),
 		}
 		s.discharger.FinishInteraction(ctx, w, req, cavs, nil)
 		httprequest.WriteJSON(w, http.StatusOK, agent.AgentResponse{
@@ -531,7 +520,7 @@ func (s *agentSuite) defaultHandle(ctx context.Context, w http.ResponseWriter, r
 	version := httpbakery.RequestVersion(req)
 	m, err := s.agentBakery.Oven.NewMacaroon(ctx, version, ages, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(userPublicKey, version),
-		declaredUsernameCaveat(username),
+		checkers.DeclaredCaveat("username", username),
 	}, bakery.LoginOp)
 
 	if err != nil {
@@ -541,18 +530,4 @@ func (s *agentSuite) defaultHandle(ctx context.Context, w http.ResponseWriter, r
 		return
 	}
 	httpbakery.WriteDischargeRequiredError(w, m, "", authErr)
-}
-
-func declaredUsernameCaveat(user string) checkers.Caveat {
-	return checkers.Caveat{
-		Condition: checkers.Condition("declared-username", user),
-		Namespace: agentTestNamespace,
-	}
-}
-
-func newChecker() *checkers.Checker {
-	c := checkers.New(nil)
-	c.Namespace().Register(agentTestNamespace, "")
-	checkers.RegisterDeclaredCaveat(c, "declared-username", agentTestNamespace)
-	return c
 }


### PR DESCRIPTION
After some thought, it has become clear that the path
ahead isn't that obvious and the declarations aren't so
easily simplified because of security concerns related
to the declaration caveat name changes. This reverts back
to the previous state of affairs until we can decide the
best way forward.

This reverts PR #139.