### PR TITLE
httpbakery/agent: support serialization

### DIFF
--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -6,6 +6,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 )
@@ -38,6 +39,12 @@ func (*KeysSuite) TestMarshalText(c *gc.C) {
 	c.Assert(key1, gc.Equals, testKey)
 }
 
+func (*KeysSuite) TestUnmarshalTextWrongKeyLength(c *gc.C) {
+	var key bakery.Key
+	err := key.UnmarshalText([]byte("aGVsbG8K"))
+	c.Assert(err, gc.ErrorMatches, `wrong length for key, got 6 want 32`)
+}
+
 func (*KeysSuite) TestKeyPairMarshalJSON(c *gc.C) {
 	kp := bakery.KeyPair{
 		Public:  bakery.PublicKey{testKey},
@@ -46,18 +53,86 @@ func (*KeysSuite) TestKeyPairMarshalJSON(c *gc.C) {
 	kp.Private.Key[0] = 99
 	data, err := json.Marshal(kp)
 	c.Assert(err, gc.IsNil)
-	var x interface{}
+	var x map[string]interface{}
 	err = json.Unmarshal(data, &x)
 	c.Assert(err, gc.IsNil)
 
 	// Check that the fields have marshaled as strings.
-	c.Assert(x.(map[string]interface{})["private"], gc.FitsTypeOf, "")
-	c.Assert(x.(map[string]interface{})["public"], gc.FitsTypeOf, "")
+	c.Assert(x["private"], gc.FitsTypeOf, "")
+	c.Assert(x["public"], gc.FitsTypeOf, "")
 
 	var kp1 bakery.KeyPair
 	err = json.Unmarshal(data, &kp1)
 	c.Assert(err, gc.IsNil)
 	c.Assert(kp1, jc.DeepEquals, kp)
+}
+
+func (*KeysSuite) TestKeyPairMarshalYAML(c *gc.C) {
+	kp := bakery.KeyPair{
+		Public:  bakery.PublicKey{testKey},
+		Private: bakery.PrivateKey{testKey},
+	}
+	kp.Private.Key[0] = 99
+	data, err := yaml.Marshal(kp)
+	c.Assert(err, gc.IsNil)
+	var x map[string]interface{}
+	err = yaml.Unmarshal(data, &x)
+	c.Assert(err, gc.IsNil)
+
+	// Check that the fields have marshaled as strings.
+	c.Assert(x["private"], gc.FitsTypeOf, "")
+	c.Assert(x["public"], gc.FitsTypeOf, "")
+
+	var kp1 bakery.KeyPair
+	err = yaml.Unmarshal(data, &kp1)
+	c.Assert(err, gc.IsNil)
+	c.Assert(kp1, jc.DeepEquals, kp)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalJSONMissingPublicKey(c *gc.C) {
+	data := `{"private": "7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU="}`
+	var k bakery.KeyPair
+	err := json.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `missing public key`)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalJSONMissingPrivateKey(c *gc.C) {
+	data := `{"public": "7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU="}`
+	var k bakery.KeyPair
+	err := json.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `missing private key`)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalJSONEmptyKeys(c *gc.C) {
+	data := `{"private": "", "public": ""}`
+	var k bakery.KeyPair
+	err := json.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `wrong length for key, got 0 want 32`)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalJSONNoKeys(c *gc.C) {
+	data := `{}`
+	var k bakery.KeyPair
+	err := json.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `missing public key`)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalYAMLMissingPublicKey(c *gc.C) {
+	data := `
+private: 7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU=
+`
+	var k bakery.KeyPair
+	err := yaml.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `missing public key`)
+}
+
+func (*KeysSuite) TestKeyPairUnmarshalYAMLMissingPrivateKey(c *gc.C) {
+	data := `
+public: 7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU=
+`
+	var k bakery.KeyPair
+	err := yaml.Unmarshal([]byte(data), &k)
+	c.Assert(err, gc.ErrorMatches, `missing private key`)
 }
 
 func newTestKey(n byte) bakery.Key {

--- a/httpbakery/agent/cookie.go
+++ b/httpbakery/agent/cookie.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+
+	"gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+)
+
+const cookieName = "agent-login"
+
+// agentLogin defines the structure of an agent login cookie.
+type agentLogin struct {
+	Username  string            `json:"username"`
+	PublicKey *bakery.PublicKey `json:"public_key"`
+}
+
+// setCookie sets an agent-login cookie with the specified parameters on
+// the given request.
+func setCookie(req *http.Request, username string, key *bakery.PublicKey) {
+	al := agentLogin{
+		Username:  username,
+		PublicKey: key,
+	}
+	data, err := json.Marshal(al)
+	if err != nil {
+		// This should be impossible as the agentLogin structure
+		// has to be marshalable. It is certainly a bug if it
+		// isn't.
+		panic(errgo.Notef(err, "cannot marshal %s cookie", cookieName))
+	}
+	req.AddCookie(&http.Cookie{
+		Name:  cookieName,
+		Value: base64.StdEncoding.EncodeToString(data),
+	})
+}
+
+// ErrNoAgentLoginCookie is the error returned when the expected
+// agent login cookie has not been found.
+var ErrNoAgentLoginCookie = errgo.New("no agent-login cookie found")
+
+// LoginCookie returns details of the agent login cookie
+// from the given request. If no agent-login cookie is found,
+// it returns an ErrNoAgentLoginCookie error.
+func LoginCookie(req *http.Request) (username string, key *bakery.PublicKey, err error) {
+	c, err := req.Cookie(cookieName)
+	if err != nil {
+		return "", nil, ErrNoAgentLoginCookie
+	}
+	b, err := base64.StdEncoding.DecodeString(c.Value)
+	if err != nil {
+		return "", nil, errgo.Notef(err, "cannot decode cookie value")
+	}
+	var al agentLogin
+	if err := json.Unmarshal(b, &al); err != nil {
+		return "", nil, errgo.Notef(err, "cannot unmarshal agent login")
+	}
+	if al.Username == "" {
+		return "", nil, errgo.Newf("agent login has no user name")
+	}
+	if al.PublicKey == nil {
+		return "", nil, errgo.Newf("agent login has no public key")
+	}
+	return al.Username, al.PublicKey, nil
+}

--- a/httpbakery/agent/serialize.go
+++ b/httpbakery/agent/serialize.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/yaml.v2"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+)
+
+// Agents holds the serialized form of a Visitor - it is
+// used by the JSON and YAML marshal and unmarshal
+// methods to serialize and deserialize a Visitor.
+// Note that any agents with a key pair that matches
+// Key will be serialized with empty keys.
+type Agents struct {
+	Key    *bakery.KeyPair `json:"key,omitempty" yaml:"key,omitempty"`
+	Agents []Agent         `json:"agents" yaml:"agents"`
+}
+
+var _ interface {
+	json.Unmarshaler
+	json.Marshaler
+	yaml.Unmarshaler
+	yaml.Marshaler
+} = (*Visitor)(nil)
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (v *Visitor) UnmarshalJSON(data []byte) error {
+	var adata Agents
+	if err := json.Unmarshal(data, &adata); err != nil {
+		return errgo.Mask(err)
+	}
+	return v.setAgentsData(&adata)
+}
+
+// MarshalJSON implements JSON.Marshaler.
+func (v *Visitor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.agentsData())
+}
+
+// MarshalYAML implements yaml.Marshaler
+func (v *Visitor) MarshalYAML() (interface{}, error) {
+	return v.agentsData(), nil
+}
+
+// UmmarshalYAML implements yaml.Unmarshaler.
+func (v *Visitor) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var adata Agents
+	if err := unmarshal(&adata); err != nil {
+		return errgo.Mask(err)
+	}
+	return v.setAgentsData(&adata)
+}
+
+func (v *Visitor) agentsData() *Agents {
+	adata := Agents{
+		Key:    v.defaultKey,
+		Agents: v.Agents(),
+	}
+	if adata.Key == nil {
+		return &adata
+	}
+	// Omit all keys that match the default key.
+	for _, a := range adata.Agents {
+		if *a.Key == *adata.Key {
+			a.Key = nil
+		}
+	}
+	return &adata
+}
+
+func (v *Visitor) setAgentsData(adata *Agents) error {
+	v.defaultKey = adata.Key
+	v.agents = make(map[string][]agent)
+	for _, a := range adata.Agents {
+		if err := v.AddAgent(a); err != nil {
+			return errgo.Notef(err, "cannot add agent at URL %q", a.URL)
+		}
+	}
+	return nil
+}

--- a/httpbakery/agent/serialize_test.go
+++ b/httpbakery/agent/serialize_test.go
@@ -1,0 +1,159 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
+)
+
+var _ httpbakery.Visitor = (*agent.Visitor)(nil)
+
+type serializeSuite struct {
+}
+
+var _ = gc.Suite(&serializeSuite{})
+
+var unmarshalJSONTests = []struct {
+	about            string
+	data             string
+	expectError      string
+	expectDefaultKey *bakery.KeyPair
+	expectAgents     []agent.Agent
+}{{
+	about: "with default",
+	data: `
+{
+	"key": {
+		"public": "en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ=",
+		"private": "gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="
+	},
+	"agents": [{
+		"url": "http://example.com/",
+		"username": "bob"
+	}, {
+		"url": "http://other.example/foo",
+		"username": "otherbob"
+	}]
+}`,
+	expectDefaultKey: parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	expectAgents: []agent.Agent{{
+		URL:      "http://example.com/",
+		Username: "bob",
+		Key:      parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	}, {
+		URL:      "http://other.example/foo",
+		Username: "otherbob",
+		Key:      parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	}},
+}, {
+	about: "no default",
+	data: `
+{
+	"agents": [{
+		"url": "http://example.com/",
+		"username": "bob",
+		"key": {
+			"public": "en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ=",
+			"private": "gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="
+		}
+	}, {
+		"url": "http://other.example/foo",
+		"username": "otherbob",
+		"key": {
+			"public": "nvNhxAaq4f8Ug9cO5hf0sRFGZbr+aLqAQsEeMgWYhTY=",
+			"private": "7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU="
+		}
+	}]
+}`,
+	expectAgents: []agent.Agent{{
+		URL:      "http://example.com/",
+		Username: "bob",
+		Key:      parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	}, {
+		URL:      "http://other.example/foo",
+		Username: "otherbob",
+		Key:      parseKeyPair("nvNhxAaq4f8Ug9cO5hf0sRFGZbr+aLqAQsEeMgWYhTY= 7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU="),
+	}},
+}, {
+	about: "agent with no key",
+	data: `
+{
+	"agents": [{
+		"url": "http://example.com/",
+		"username": "bob"
+	}]
+}`,
+	expectError: `cannot add agent at URL "http://example.com/": no key for agent`,
+}, {
+	about: "agent with missing private key",
+	data: `
+{
+	"agents": [{
+		"url": "http://example.com/",
+		"username": "bob",
+		"key": {
+			"public": "nvNhxAaq4f8Ug9cO5hf0sRFGZbr+aLqAQsEeMgWYhTY="
+		}
+	}]
+}`,
+	// TODO it would be nice if encoding/json could provide more contextual
+	// information for errors like this.
+	expectError: `missing private key`,
+}}
+
+func (s *serializeSuite) TestUnmarshalJSON(c *gc.C) {
+	for i, test := range unmarshalJSONTests {
+		c.Logf("test %d: %v", i, test.about)
+		var v agent.Visitor
+		err := json.Unmarshal([]byte(test.data), &v)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(v.DefaultKey(), jc.DeepEquals, test.expectDefaultKey)
+		c.Assert(v.Agents(), jc.DeepEquals, test.expectAgents)
+	}
+}
+
+func (s *serializeSuite) TestUnmarshalYAML(c *gc.C) {
+	for i, test := range unmarshalJSONTests {
+		c.Logf("test %d: %v", i, test.about)
+		var x interface{}
+		err := json.Unmarshal([]byte(test.data), &x)
+		c.Assert(err, gc.IsNil)
+		ydata, err := yaml.Marshal(x)
+		c.Assert(err, gc.IsNil)
+
+		var v agent.Visitor
+		err = yaml.Unmarshal(ydata, &v)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(v.DefaultKey(), jc.DeepEquals, test.expectDefaultKey)
+		c.Assert(v.Agents(), jc.DeepEquals, test.expectAgents)
+	}
+}
+
+func parseKeyPair(s string) *bakery.KeyPair {
+	parts := strings.Split(s, " ")
+	var k bakery.KeyPair
+	err := k.Public.UnmarshalText([]byte(parts[0]))
+	if err != nil {
+		panic(err)
+	}
+	err = k.Private.UnmarshalText([]byte(parts[1]))
+	if err != nil {
+		panic(err)
+	}
+	return &k
+}


### PR DESCRIPTION
Also make key pair unmarshaling a little more robust in bakery.