### PR TITLE
bakery/agent: allow multiple users for a URL

### DIFF
--- a/httpbakery/agent/serialize.go
+++ b/httpbakery/agent/serialize.go
@@ -74,7 +74,9 @@ func (v *Visitor) agentsData() *Agents {
 func (v *Visitor) setAgentsData(adata *Agents) error {
 	v.defaultKey = adata.Key
 	v.agents = make(map[string][]agent)
-	for _, a := range adata.Agents {
+	// Add the agents in reverse order so that the precedence remains the same.
+	for i := len(adata.Agents)-1; i >= 0; i-- {
+		a := adata.Agents[i]
 		if err := v.AddAgent(a); err != nil {
 			return errgo.Notef(err, "cannot add agent at URL %q", a.URL)
 		}

--- a/httpbakery/agent/serialize_test.go
+++ b/httpbakery/agent/serialize_test.go
@@ -106,6 +106,32 @@ var unmarshalJSONTests = []struct {
 	// TODO it would be nice if encoding/json could provide more contextual
 	// information for errors like this.
 	expectError: `missing private key`,
+}, {
+	about: "multiple users for a single URL",
+	data: `
+{
+	"key": {
+		"public": "en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ=",
+		"private": "gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="
+	},
+	"agents": [{
+		"url": "http://example.com/",
+		"username": "bob"
+	}, {
+		"url": "http://example.com/",
+		"username": "otherbob"
+	}]
+}`,
+	expectDefaultKey: parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	expectAgents: []agent.Agent{{
+		URL:      "http://example.com/",
+		Username: "bob",
+		Key:      parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	}, {
+		URL:      "http://example.com/",
+		Username: "otherbob",
+		Key:      parseKeyPair("en/IpDvPYUOSOA71WnIVNVQ5N+1vLOVQtvgIa9UUyhQ= gyeCwDRCGVpFaqJVnu2VPalW4IRJQ9hqxo0LPTYHyUU="),
+	}},
 }}
 
 func (s *serializeSuite) TestUnmarshalJSON(c *gc.C) {


### PR DESCRIPTION
This allows a serialized agent file to contain several agents for a
given third party.  Only the most recently added will be used, but
users can manually edit the serialized form to change the preference,
and a future change may allow the preference to be expressed otherwise.

With this in place, the put-agent command will be able
to create a new agent entry without worrying about
overwriting potentially irretrievable private key data.