### PR TITLE
httpbakery: allow empty origin headers when checking caveats

### DIFF
--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -101,7 +101,7 @@ func clientOriginCheck(ctx context.Context, cond, args string) error {
 	if req == nil {
 		return errgo.Newf("no origin found in context")
 	}
-	if reqOrigin := req.Header.Get("Origin"); reqOrigin != args {
+	if reqOrigin := req.Header.Get("Origin"); reqOrigin != "" && reqOrigin != args {
 		return errgo.Newf("request has invalid Origin header; got %q", reqOrigin)
 	}
 	return nil

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -136,8 +136,7 @@ var checkerTests = []struct {
 	checks: []checkTest{{
 		caveat: httpbakery.ClientOriginCaveat(""),
 	}, {
-		caveat:      httpbakery.ClientOriginCaveat("somewhere"),
-		expectError: `caveat "http:origin somewhere" not satisfied: request has invalid Origin header; got ""`,
+		caveat: httpbakery.ClientOriginCaveat("somewhere"),
 	}},
 }, {
 	about: "request with origin",


### PR DESCRIPTION
This is cherry-picked from https://github.com/go-macaroon-bakery/macaroon-bakery/pull/137.