### PR TITLE
httpbakery: allow empty origin headers when checking caveats

### DIFF
--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -48,7 +48,10 @@ func (c httpContext) clientIPAddr(_, addr string) error {
 // clientOrigin implements the Origin header checker
 // for an HTTP request.
 func (c httpContext) clientOrigin(_, origin string) error {
-	if reqOrigin := c.req.Header.Get("Origin"); reqOrigin != origin {
+	// Note that web browsers may not provide the origin header when it's
+	// not a cross-site request with a GET method. There's nothing we
+	// can do about that, so just allow all requests with an empty origin.
+	if reqOrigin := c.req.Header.Get("Origin"); reqOrigin != "" && reqOrigin != origin {
 		return errgo.Newf("request has invalid Origin header; got %q", reqOrigin)
 	}
 	return nil

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -104,7 +104,7 @@ var checkerTests = []struct {
 		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
 			RemoteAddr: "bad",
 		}).Condition,
-		expectError: `caveat "error cannot parse host port in remote address: missing port in address bad" not satisfied: bad caveat`,
+		expectError: `caveat "error cannot parse host port in remote address: .*" not satisfied: bad caveat`,
 	}, {
 		caveat: httpbakery.SameClientIPAddrCaveat(&http.Request{
 			RemoteAddr: "bad:56",
@@ -132,8 +132,7 @@ var checkerTests = []struct {
 	checks: []checkTest{{
 		caveat: checkers.ClientOriginCaveat("").Condition,
 	}, {
-		caveat:      checkers.ClientOriginCaveat("somewhere").Condition,
-		expectError: `caveat "origin somewhere" not satisfied: request has invalid Origin header; got ""`,
+		caveat: checkers.ClientOriginCaveat("somewhere").Condition,
 	}},
 }, {
 	about: "request with origin",


### PR DESCRIPTION
This is back-ported from PR #137.