### PR TITLE
bakery: add context to DeclaredIdentity call

### DIFF
--- a/bakery/checker.go
+++ b/bakery/checker.go
@@ -195,7 +195,7 @@ func (a *AuthChecker) initOnceFunc(ctx context.Context) error {
 			// for the purposes of identity.
 			continue
 		}
-		identity, err := a.p.IdentityClient.DeclaredIdentity(declared)
+		identity, err := a.p.IdentityClient.DeclaredIdentity(ctx, declared)
 		if err != nil {
 			a.initErrors = append(a.initErrors, errgo.Notef(err, "cannot decode declared identity: %v", err))
 			continue

--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -653,7 +653,7 @@ func (ids *idService) IdentityFromContext(ctx context.Context) (bakery.Identity,
 	}}, nil
 }
 
-func (ids *idService) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+func (ids *idService) DeclaredIdentity(ctx context.Context, declared map[string]string) (bakery.Identity, error) {
 	user, ok := declared["username"]
 	if !ok {
 		return nil, errgo.Newf("no username declared")
@@ -682,7 +682,7 @@ func (basicAuthIdService) IdentityFromContext(ctx context.Context) (bakery.Ident
 	return bakery.SimpleIdentity(user), nil, nil
 }
 
-func (basicAuthIdService) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+func (basicAuthIdService) DeclaredIdentity(ctx context.Context, declared map[string]string) (bakery.Identity, error) {
 	return nil, errgo.Newf("no identity declarations in basic auth id service")
 }
 

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -73,7 +73,7 @@ func (oneIdentity) IdentityFromContext(ctx context.Context) (bakery.Identity, []
 	return nil, nil, nil
 }
 
-func (oneIdentity) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+func (oneIdentity) DeclaredIdentity(ctx context.Context, declared map[string]string) (bakery.Identity, error) {
 	return noone{}, nil
 }
 

--- a/bakery/identity.go
+++ b/bakery/identity.go
@@ -26,7 +26,7 @@ type IdentityClient interface {
 	// DeclaredIdentity parses the identity declaration from the given
 	// declared attributes.
 	// TODO take the set of first party caveat conditions instead?
-	DeclaredIdentity(declared map[string]string) (Identity, error)
+	DeclaredIdentity(ctx context.Context, declared map[string]string) (Identity, error)
 }
 
 // Identity holds identity information declared in a first party caveat
@@ -55,7 +55,7 @@ func (noIdentities) IdentityFromContext(ctx context.Context) (Identity, []checke
 
 // DeclaredIdentity implements IdentityClient.DeclaredIdentity by
 // always returning an error.
-func (noIdentities) DeclaredIdentity(declared map[string]string) (Identity, error) {
+func (noIdentities) DeclaredIdentity(ctx context.Context, declared map[string]string) (Identity, error) {
 	return nil, errgo.Newf("no identity declared or possible")
 }
 

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -463,7 +463,7 @@ func identityCaveats(dischargerURL string) []checkers.Caveat {
 	}}
 }
 
-func (c idmClient) DeclaredIdentity(declared map[string]string) (bakery.Identity, error) {
+func (c idmClient) DeclaredIdentity(ctx context.Context, declared map[string]string) (bakery.Identity, error) {
 	return bakery.SimpleIdentity(declared["username"]), nil
 }
 

--- a/httpbakery/agent/serialize.go
+++ b/httpbakery/agent/serialize.go
@@ -75,7 +75,7 @@ func (v *Visitor) setAgentsData(adata *Agents) error {
 	v.defaultKey = adata.Key
 	v.agents = make(map[string][]agent)
 	// Add the agents in reverse order so that the precedence remains the same.
-	for i := len(adata.Agents)-1; i >= 0; i-- {
+	for i := len(adata.Agents) - 1; i >= 0; i-- {
 		a := adata.Agents[i]
 		if err := v.AddAgent(a); err != nil {
 			return errgo.Notef(err, "cannot add agent at URL %q", a.URL)


### PR DESCRIPTION
This allows an IdentityClient to make context-specific
decisions about whether a given identity is allowed or not.