### PR TITLE
bakery/example: fix for new API

### DIFF
--- a/bakery/bakery.go
+++ b/bakery/bakery.go
@@ -68,8 +68,9 @@ type BakeryParams struct {
 	Location string
 }
 
-// New returns a new Bakery instance which contains an Oven with a Bakery
-// for the convenience of callers that wish to use both together.
+// New returns a new Bakery instance which combines an Oven with a
+// Checker for the convenience of callers that wish to use both
+// together.
 func New(p BakeryParams) *Bakery {
 	if p.Checker == nil {
 		p.Checker = checkers.New(nil)

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -1,5 +1,3 @@
-// +build ignore
-
 package main
 
 import (

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -1,11 +1,10 @@
-// +build ignore
-
 package main
 
 import (
 	"net/http"
 	"testing"
 
+	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
@@ -16,6 +15,7 @@ func TestPackage(t *testing.T) {
 }
 
 type exampleSuite struct {
+	jujutesting.LoggingSuite
 	authEndpoint  string
 	authPublicKey *bakery.PublicKey
 }
@@ -23,6 +23,7 @@ type exampleSuite struct {
 var _ = gc.Suite(&exampleSuite{})
 
 func (s *exampleSuite) SetUpSuite(c *gc.C) {
+	s.LoggingSuite.SetUpSuite(c)
 	key, err := bakery.GenerateKey()
 	c.Assert(err, gc.IsNil)
 	s.authPublicKey = &key.Public

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -1,5 +1,3 @@
-// +build ignore
-
 // This example demonstrates three components:
 //
 // - A target service, representing a web server that

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -1,11 +1,9 @@
-// +build ignore
-
 package main
 
 import (
 	"fmt"
-	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -17,7 +15,7 @@ import (
 )
 
 type targetServiceHandler struct {
-	svc          *bakery.Service
+	bakery       *bakery.Bakery
 	authEndpoint string
 	endpoint     string
 	mux          *http.ServeMux
@@ -34,79 +32,110 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 	}
 	pkLocator := httpbakery.NewThirdPartyLocator(nil, nil)
 	pkLocator.AllowInsecure()
-	svc, err := bakery.NewService(bakery.NewServiceParams{
+	b := bakery.New(bakery.BakeryParams{
 		Key:      key,
 		Location: endpoint,
 		Locator:  pkLocator,
 		Checker:  httpbakery.NewChecker(),
+		Authorizer: authorizer{
+			thirdPartyLocation: authEndpoint,
+		},
 	})
-	if err != nil {
-		return nil, err
-	}
 	mux := http.NewServeMux()
 	srv := &targetServiceHandler{
-		svc:          svc,
+		bakery:       b,
 		authEndpoint: authEndpoint,
 	}
-	mux.HandleFunc("/gold/", srv.serveGold)
-	mux.HandleFunc("/silver/", srv.serveSilver)
+	mux.Handle("/gold/", srv.auth(http.HandlerFunc(srv.serveGold)))
+	mux.Handle("/silver/", srv.auth(http.HandlerFunc(srv.serveSilver)))
 	return mux, nil
 }
 
 func (srv *targetServiceHandler) serveGold(w http.ResponseWriter, req *http.Request) {
-	ctx := checkers.ContextWithOperations(context.TODO(), "gold")
-	if _, _, err := httpbakery.CheckRequest(ctx, srv.svc, req, nil); err != nil {
-		srv.writeError(w, req, "gold", err)
-		return
-	}
 	fmt.Fprintf(w, "all is golden")
 }
 
 func (srv *targetServiceHandler) serveSilver(w http.ResponseWriter, req *http.Request) {
-	ctx := checkers.ContextWithOperations(context.TODO(), "silver")
-	if _, _, err := httpbakery.CheckRequest(ctx, srv.svc, req, nil); err != nil {
-		srv.writeError(w, req, "silver", err)
-		return
-	}
 	fmt.Fprintf(w, "every cloud has a silver lining")
+}
+
+// auth wraps the given handler with a handler that provides
+// authorization by inspecting the HTTP request
+// to decide what authorization is required.
+func (srv *targetServiceHandler) auth(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := httpbakery.ContextWithRequest(req.Context(), req)
+		ops, err := opsForRequest(req)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "%v", err)
+			return
+		}
+		authChecker := srv.bakery.Checker.Auth(httpbakery.RequestMacaroons(req)...)
+		if _, err = authChecker.Allow(ctx, ops...); err != nil {
+			srv.writeError(ctx, w, req, err)
+			return
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
+// opsForRequest returns the required operations
+// implied by the given HTTP request.
+func opsForRequest(req *http.Request) ([]bakery.Op, error) {
+	if !strings.HasPrefix(req.URL.Path, "/") {
+		return nil, errgo.Newf("bad path")
+	}
+	elems := strings.Split(req.URL.Path, "/")
+	if len(elems) < 2 {
+		return nil, errgo.Newf("bad path")
+	}
+	return []bakery.Op{{
+		Entity: elems[1],
+		Action: req.Method,
+	}}, nil
 }
 
 // writeError writes an error to w in response to req. If the error was
 // generated because of a required macaroon that the client does not
 // have, we mint a macaroon that, when discharged, will grant the client
 // the right to execute the given operation.
-//
-// The logic in this function is crucial to the security of the service
-// - it must determine for a given operation what caveats to attach.
-func (srv *targetServiceHandler) writeError(w http.ResponseWriter, req *http.Request, operation string, verr error) {
-	log.Printf("writing error with operation %q", operation)
-	fail := func(code int, msg string, args ...interface{}) {
-		if code == http.StatusInternalServerError {
-			msg = "internal error: " + msg
-		}
-		http.Error(w, fmt.Sprintf(msg, args...), code)
-	}
-
-	if _, ok := errgo.Cause(verr).(*bakery.VerificationError); !ok {
-		fail(http.StatusForbidden, "%v", verr)
+func (srv *targetServiceHandler) writeError(ctx context.Context, w http.ResponseWriter, req *http.Request, verr error) {
+	derr, ok := errgo.Cause(verr).(*bakery.DischargeRequiredError)
+	if !ok {
+		fail(w, http.StatusForbidden, "%v", verr)
 		return
-	}
-
-	// Work out what caveats we need to apply for the given operation.
-	// Could special-case the operation here if desired.
-	caveats := []checkers.Caveat{
-		checkers.TimeBeforeCaveat(time.Now().Add(5 * time.Minute)),
-		checkers.AllowCaveat(operation),
-		{
-			Location:  srv.authEndpoint,
-			Condition: "access-allowed",
-		},
 	}
 	// Mint an appropriate macaroon and send it back to the client.
-	m, err := srv.svc.NewMacaroon(httpbakery.RequestVersion(req), caveats)
+	m, err := srv.bakery.Oven.NewMacaroon(ctx, httpbakery.RequestVersion(req), time.Now().Add(5*time.Minute), derr.Caveats, derr.Ops...)
 	if err != nil {
-		fail(http.StatusInternalServerError, "cannot mint macaroon: %v", err)
+		fail(w, http.StatusInternalServerError, "cannot mint macaroon: %v", err)
 		return
 	}
-	httpbakery.WriteDischargeRequiredErrorForRequest(w, m, "", verr, req)
+
+	herr := httpbakery.NewDischargeRequiredError(m, "/", derr, req)
+	herr.(*httpbakery.Error).Info.CookieNameSuffix = "auth"
+	httpbakery.WriteError(ctx, w, herr)
+}
+
+func fail(w http.ResponseWriter, code int, msg string, args ...interface{}) {
+	http.Error(w, fmt.Sprintf(msg, args...), code)
+}
+
+type authorizer struct {
+	thirdPartyLocation string
+}
+
+// Authorize implements bakery.Authorizer.Authorize by
+// allowing anyone to do anything if a third party
+// approves it.
+func (a authorizer) Authorize(ctx context.Context, id bakery.Identity, ops []bakery.Op) (allowed []bool, caveats []checkers.Caveat, err error) {
+	allowed = make([]bool, len(ops))
+	for i := range allowed {
+		allowed[i] = true
+	}
+	caveats = []checkers.Caveat{{
+		Location:  a.thirdPartyLocation,
+		Condition: "access-allowed",
+	}}
+	return
 }

--- a/bakery/oven.go
+++ b/bakery/oven.go
@@ -228,7 +228,7 @@ func (o *Oven) NewMacaroon(ctx context.Context, version Version, expiry time.Tim
 	}
 	m, err := NewMacaroon(rootKey, idBytes, o.p.Location, version, o.p.Namespace)
 	if err != nil {
-		return nil, errgo.Notef(err, "cannot create macaroon")
+		return nil, errgo.Notef(err, "cannot create macaroon with version %v", version)
 	}
 	if err := o.AddCaveat(ctx, m, checkers.TimeBeforeCaveat(expiry)); err != nil {
 		return nil, errgo.Mask(err)

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -529,5 +529,6 @@ func (s *agentSuite) defaultHandle(ctx context.Context, w http.ResponseWriter, r
 		})
 		return
 	}
-	httpbakery.WriteDischargeRequiredError(w, m, "", authErr)
+	err = httpbakery.NewDischargeRequiredError(m, "", authErr, req)
+	httpbakery.WriteError(ctx, w, err)
 }

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -89,6 +89,10 @@ func NewHTTPClient() *http.Client {
 			return nil
 		}
 		for attr, val := range via[0].Header {
+			if attr == "Cookie" {
+				// Cookies are added automatically anyway.
+				continue
+			}
 			if _, ok := req.Header[attr]; !ok {
 				req.Header[attr] = val
 			}

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -439,7 +439,8 @@ func (s *ClientSuite) serverRequiringMultipleDischarges(n int, discharger *baker
 		if err != nil {
 			panic(fmt.Errorf("cannot make new macaroon: %v", err))
 		}
-		httpbakery.WriteDischargeRequiredErrorForRequest(w, m, "", errgo.New("foo"), req)
+		err = httpbakery.NewDischargeRequiredError(m, "", errgo.New("foo"), req)
+		httpbakery.WriteError(testContext, w, err)
 	}))
 }
 
@@ -447,7 +448,8 @@ func (s *ClientSuite) TestVersion0Generates407Status(c *gc.C) {
 	m, err := bakery.NewMacaroon([]byte("root key"), []byte("id"), "location", bakery.Version0, nil)
 	c.Assert(err, gc.IsNil)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		httpbakery.WriteDischargeRequiredErrorForRequest(w, m, "", errgo.New("foo"), req)
+		err := httpbakery.NewDischargeRequiredError(m, "", errgo.New("foo"), req)
+		httpbakery.WriteError(testContext, w, err)
 	}))
 	defer srv.Close()
 	resp, err := http.Get(srv.URL)
@@ -459,7 +461,8 @@ func (s *ClientSuite) TestVersion1Generates401Status(c *gc.C) {
 	m, err := bakery.NewMacaroon([]byte("root key"), []byte("id"), "location", bakery.Version1, nil)
 	c.Assert(err, gc.IsNil)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		httpbakery.WriteDischargeRequiredErrorForRequest(w, m, "", errgo.New("foo"), req)
+		err := httpbakery.NewDischargeRequiredError(m, "", errgo.New("foo"), req)
+		httpbakery.WriteError(testContext, w, err)
 	}))
 	defer srv.Close()
 

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -68,8 +68,9 @@ func (s *ErrorSuite) TestWriteDischargeRequiredError(c *gc.C) {
 	for i, t := range tests {
 		c.Logf("Running test %d %s", i, t.about)
 		response := httptest.NewRecorder()
-		httpbakery.WriteDischargeRequiredError(response, m, t.path, t.err)
-		httptesting.AssertJSONResponse(c, response, http.StatusProxyAuthRequired, t.expectedResponse)
+		err := httpbakery.NewDischargeRequiredErrorWithVersion(m, t.path, t.err, bakery.Version3)
+		httpbakery.WriteError(testContext, response, err)
+		httptesting.AssertJSONResponse(c, response, http.StatusUnauthorized, t.expectedResponse)
 	}
 }
 


### PR DESCRIPTION
We fix the example so it works and its structure is more idiomatic.

We also clean up some of the error-related functions in
the httpbakery API, removing some deprecated
functions, shortening some names, and exporting
the WriteError function.