### PR TITLE
httpbakery: allow base64-encoded token in WaitTokenResponse

### DIFF
--- a/bakery/authorizer.go
+++ b/bakery/authorizer.go
@@ -133,6 +133,8 @@ func (a ACLAuthorizer) Authorize(ctx context.Context, ident Identity, ops []Op) 
 				return nil, nil, errgo.Notef(err, "cannot check permissions")
 			}
 		} else {
+			// TODO should we allow "everyone" when the identity is
+			// non-nil but isn't an ACLIdentity?
 			allowed[i] = a.AllowPublic && isPublicACL(acl)
 		}
 	}

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -1,6 +1,7 @@
 package bakery_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"unicode/utf8"
 

--- a/bakery/macaroon.go
+++ b/bakery/macaroon.go
@@ -21,7 +21,7 @@ func legacyNamespace() *checkers.Namespace {
 	return ns
 }
 
-// Macaroon represents an undischarged macaroon along its first
+// Macaroon represents an undischarged macaroon along with its first
 // party caveat namespace and associated third party caveat information
 // which should be passed to the third party when discharging a caveat.
 type Macaroon struct {

--- a/bakery/macaroon_test.go
+++ b/bakery/macaroon_test.go
@@ -91,7 +91,6 @@ func (*macaroonSuite) TestAddThirdPartyCaveat(c *gc.C) {
 		for _, id := range test.existingCaveatIds {
 			err := m.M().AddThirdPartyCaveat(nil, id, "")
 			c.Assert(err, gc.IsNil)
-
 		}
 		bakery.SetMacaroonCaveatIdPrefix(m, test.baseId)
 		err = m.AddCaveat(testContext, checkers.Caveat{


### PR DESCRIPTION
This makes it easy for a visit-wait implementation to use a binary token.