### PR TITLE
bakery: add Checker.Allowed method

### DIFF
--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -1,7 +1,6 @@
 package bakery_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"unicode/utf8"
 


### PR DESCRIPTION
This allows a server to find a client's allowed operations
without knowing them in advance.