### PR TITLE
bakery: add Slice type

### DIFF
--- a/bakery/dischargeall_test.go
+++ b/bakery/dischargeall_test.go
@@ -32,7 +32,7 @@ func (*DischargeSuite) TestDischargeAllNoDischarges(c *gc.C) {
 	ms, err := bakery.DischargeAll(testContext, m, noDischarge(c))
 	c.Assert(err, gc.IsNil)
 	c.Assert(ms, gc.HasLen, 1)
-	c.Assert(ms[0], gc.Equals, m.M())
+	c.Assert(ms[0].Signature(), gc.DeepEquals, m.M().Signature())
 
 	err = m.M().Verify(rootKey, alwaysOK, nil)
 	c.Assert(err, gc.IsNil)

--- a/bakery/keys.go
+++ b/bakery/keys.go
@@ -101,7 +101,7 @@ type ThirdPartyLocator interface {
 	ThirdPartyInfo(ctx context.Context, loc string) (ThirdPartyInfo, error)
 }
 
-// ThirdPartyLocatorMap implements a simple ThirdPartyLocator.
+// ThirdPartyStore implements a simple ThirdPartyLocator.
 // A trailing slash on locations is ignored.
 type ThirdPartyStore struct {
 	m map[string]ThirdPartyInfo

--- a/bakery/slice.go
+++ b/bakery/slice.go
@@ -1,0 +1,133 @@
+package bakery
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"time"
+
+	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	macaroon "gopkg.in/macaroon.v2-unstable"
+)
+
+// Slice holds a slice of unbound macaroons.
+type Slice []*Macaroon
+
+// Bind prepares the macaroon slice for use in a request. This must be
+// done before presenting the macaroons to a service for use as
+// authorization tokens. The result will only be valid
+// if s contains discharge macaroons for all third party
+// caveats.
+//
+// All the macaroons in the returned slice will be copies
+// of this in s, not references.
+func (s Slice) Bind() macaroon.Slice {
+	if len(s) == 0 {
+		return nil
+	}
+	ms := make(macaroon.Slice, len(s))
+	ms[0] = s[0].M().Clone()
+	rootSig := ms[0].Signature()
+	for i, m := range s[1:] {
+		m1 := m.M().Clone()
+		m1.Bind(rootSig)
+		ms[i+1] = m1
+	}
+	return ms
+}
+
+// Purge returns a new slice holding all macaroons in s
+// that expire after the given time.
+func (ms Slice) Purge(t time.Time) Slice {
+	ms1 := make(Slice, 0, len(ms))
+	for i, m := range ms {
+		et, ok := checkers.ExpiryTime(m.Namespace(), m.M().Caveats())
+		if !ok || et.After(t) {
+			ms1 = append(ms1, m)
+		} else if i == 0 {
+			// The primary macaroon has expired, so all its discharges
+			// have expired too.
+			// TODO purge all discharge macaroons when the macaroon
+			// containing their third-party caveat expires.
+			return nil
+		}
+	}
+	return ms1
+}
+
+// DischargeAll discharges all the third party caveats in the slice for
+// which discharge macaroons are not already present, using getDischarge
+// to acquire the discharge macaroons. It always returns the slice with
+// any acquired discharge macaroons added, even on error. It returns an
+// error if all the discharges could not be acquired.
+//
+// Note that this differs from DischargeAll in that it can be given several existing
+// discharges, and that the resulting discharges are not bound to the primary,
+// so it's still possible to add caveats and reacquire expired discharges
+// without reacquiring the primary macaroon.
+func (ms Slice) DischargeAll(ctx context.Context, getDischarge func(ctx context.Context, cav macaroon.Caveat, encryptedCaveat []byte) (*Macaroon, error), localKey *KeyPair) (Slice, error) {
+	if len(ms) == 0 {
+		return nil, errgo.Newf("no macaroons to discharge")
+	}
+	ms1 := make(Slice, len(ms))
+	copy(ms1, ms)
+	// have holds the keys of all the macaroon ids in the slice.
+	type needCaveat struct {
+		// cav holds the caveat that needs discharge.
+		cav macaroon.Caveat
+		// encryptedCaveat holds encrypted caveat
+		// if it was held externally.
+		encryptedCaveat []byte
+	}
+	var need []needCaveat
+	have := make(map[string]bool)
+	for _, m := range ms[1:] {
+		have[string(m.M().Id())] = true
+	}
+	// addCaveats adds any required third party caveats to the need slice
+	// that aren't already present .
+	addCaveats := func(m *Macaroon) {
+		for _, cav := range m.M().Caveats() {
+			if len(cav.VerificationId) == 0 || have[string(cav.Id)] {
+				continue
+			}
+			need = append(need, needCaveat{
+				cav:             cav,
+				encryptedCaveat: m.caveatData[string(cav.Id)],
+			})
+		}
+	}
+	for _, m := range ms {
+		addCaveats(m)
+	}
+	var errs []error
+	for len(need) > 0 {
+		cav := need[0]
+		need = need[1:]
+		var dm *Macaroon
+		var err error
+		if localKey != nil && cav.cav.Location == "local" {
+			// TODO use a small caveat id.
+			dm, err = Discharge(ctx, DischargeParams{
+				Key:     localKey,
+				Checker: localDischargeChecker,
+				Caveat:  cav.encryptedCaveat,
+				Id:      cav.cav.Id,
+				Locator: emptyLocator{},
+			})
+		} else {
+			dm, err = getDischarge(ctx, cav.cav, cav.encryptedCaveat)
+		}
+		if err != nil {
+			errs = append(errs, errgo.NoteMask(err, fmt.Sprintf("cannot get discharge from %q", cav.cav.Location), errgo.Any))
+			continue
+		}
+		ms1 = append(ms1, dm)
+		addCaveats(dm)
+	}
+	if errs != nil {
+		// TODO log other errors? Return them all?
+		return ms1, errgo.Mask(errs[0], errgo.Any)
+	}
+	return ms1, nil
+}

--- a/bakery/slice_test.go
+++ b/bakery/slice_test.go
@@ -1,0 +1,202 @@
+package bakery_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/testing"
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon.v2-unstable"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+)
+
+type SliceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&SliceSuite{})
+
+func (*SliceSuite) TestAddMoreCaveats(c *gc.C) {
+	getDischarge := func(_ context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
+		c.Check(payload, gc.IsNil)
+		m, err := bakery.NewMacaroon([]byte("root key "+string(cav.Id)), cav.Id, "", bakery.LatestVersion, nil)
+		c.Assert(err, gc.Equals, nil)
+		return m, nil
+	}
+
+	rootKey := []byte("root key")
+	m, err := bakery.NewMacaroon(rootKey, []byte("id0"), "loc0", bakery.LatestVersion, testChecker.Namespace())
+	c.Assert(err, gc.Equals, nil)
+	err = m.M().AddThirdPartyCaveat([]byte("root key id1"), []byte("id1"), "somewhere")
+	c.Assert(err, gc.Equals, nil)
+
+	ms, err := bakery.Slice{m}.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	mms := ms.Bind()
+	c.Assert(mms, gc.HasLen, len(ms))
+	err = mms[0].Verify(rootKey, alwaysOK, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+
+	// Add another caveat and to the root macaroon and discharge it.
+	err = ms[0].M().AddThirdPartyCaveat([]byte("root key id2"), []byte("id2"), "somewhere else")
+	c.Assert(err, gc.Equals, nil)
+
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 3)
+
+	mms = ms.Bind()
+	err = mms[0].Verify(rootKey, alwaysOK, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+
+	// Check that we can remove the original discharge and still re-acquire it OK.
+	ms = bakery.Slice{ms[0], ms[2]}
+
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 3)
+
+	mms = ms.Bind()
+	err = mms[0].Verify(rootKey, alwaysOK, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (*SliceSuite) TestPurge(c *gc.C) {
+	t0 := time.Date(2000, time.October, 1, 12, 0, 0, 0, time.UTC)
+	clock := &stoppedClock{
+		t: t0,
+	}
+	ctx := checkers.ContextWithClock(testContext, clock)
+	checkCond := func(cond string) error {
+		return testChecker.CheckFirstPartyCaveat(ctx, cond)
+	}
+
+	rootKey := []byte("root key")
+	m, err := bakery.NewMacaroon(rootKey, []byte("id0"), "loc0", bakery.LatestVersion, testChecker.Namespace())
+	c.Assert(err, gc.Equals, nil)
+	err = m.AddCaveat(ctx, checkers.TimeBeforeCaveat(t0.Add(time.Hour)), nil, nil)
+	c.Assert(err, gc.Equals, nil)
+	err = m.M().AddThirdPartyCaveat([]byte("root key id1"), []byte("id1"), "somewhere")
+	c.Assert(err, gc.Equals, nil)
+	ms := bakery.Slice{m}
+
+	getDischarge := func(_ context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
+		c.Check(payload, gc.IsNil)
+		m, err := bakery.NewMacaroon([]byte("root key "+string(cav.Id)), cav.Id, "", bakery.LatestVersion, testChecker.Namespace())
+		c.Assert(err, gc.Equals, nil)
+		err = m.AddCaveat(ctx, checkers.TimeBeforeCaveat(clock.t.Add(time.Minute)), nil, nil)
+		c.Assert(err, gc.Equals, nil)
+		return m, nil
+	}
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	mms := ms.Bind()
+	err = mms[0].Verify(rootKey, checkCond, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+
+	// Sanity check that verification fails when the discharge time has expired.
+	clock.t = t0.Add(2 * time.Minute)
+
+	err = mms[0].Verify(rootKey, checkCond, mms[1:])
+	c.Assert(err, gc.ErrorMatches, `.*: macaroon has expired`)
+
+	// Purge removes the discharge macaroon when it's out of date.
+	ms = ms.Purge(clock.t)
+	c.Assert(ms, gc.HasLen, 1)
+
+	// Reacquire a discharge macaroon.
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	// The macaroons should now be valid again.
+	mms = ms.Bind()
+	err = mms[0].Verify(rootKey, checkCond, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+
+	// Check that when the time has gone beyond the primary
+	// macaroon's expiry time, Purge removes all the macaroons.
+
+	// Reacquire a discharge macaroon just before the primary
+	// macaroon's expiry time.
+	clock.t = t0.Add(time.Hour - time.Second)
+
+	ms = ms.Purge(clock.t)
+	c.Assert(ms, gc.HasLen, 1)
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 2)
+
+	// The macaroons should now be valid again.
+	mms = ms.Bind()
+	err = mms[0].Verify(rootKey, checkCond, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+
+	// But once we've passed the hour, the primary expires
+	// even though the discharge is valid, and purging
+	// removes both primary and discharge.
+
+	ms = ms.Purge(t0.Add(time.Hour + time.Millisecond))
+	c.Assert(ms, gc.HasLen, 0)
+}
+
+func (*SliceSuite) TestDischargeAllAcquiresManyMacaroonsAsPossible(c *gc.C) {
+	failIds := map[string]bool{
+		"id1": true,
+		"id3": true,
+	}
+
+	getDischarge := func(_ context.Context, cav macaroon.Caveat, payload []byte) (*bakery.Macaroon, error) {
+		if failIds[string(cav.Id)] {
+			return nil, errgo.Newf("discharge failure on %q", cav.Id)
+		}
+		m, err := bakery.NewMacaroon([]byte("root key "+string(cav.Id)), cav.Id, "", bakery.LatestVersion, nil)
+		c.Assert(err, gc.Equals, nil)
+		return m, nil
+	}
+
+	rootKey := []byte("root key")
+	m, err := bakery.NewMacaroon(rootKey, []byte("id-root"), "", bakery.LatestVersion, testChecker.Namespace())
+	c.Assert(err, gc.Equals, nil)
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("id%d", i)
+		err = m.M().AddThirdPartyCaveat([]byte("root key "+id), []byte(id), "somewhere")
+		c.Assert(err, gc.Equals, nil)
+	}
+	ms := bakery.Slice{m}
+
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Check(err, gc.ErrorMatches, `cannot get discharge from "somewhere": discharge failure on "id1"`)
+	c.Assert(ms, gc.HasLen, 4)
+
+	// Try again without id1 failing - we should acquire one more discharge.
+	// Mark the other ones as failing because we shouldn't be trying to acquire
+	// them because they're already in the slice.
+	failIds = map[string]bool{
+		"id0": true,
+		"id3": true,
+		"id4": true,
+	}
+
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Check(err, gc.ErrorMatches, `cannot get discharge from "somewhere": discharge failure on "id3"`)
+	c.Assert(ms, gc.HasLen, 5)
+
+	failIds["id3"] = false
+
+	ms, err = ms.DischargeAll(testContext, getDischarge, nil)
+	c.Check(err, gc.Equals, nil)
+	c.Assert(ms, gc.HasLen, 6)
+
+	mms := ms.Bind()
+	err = mms[0].Verify(rootKey, alwaysOK, mms[1:])
+	c.Assert(err, gc.Equals, nil)
+}

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -199,6 +199,12 @@ func (c *Client) DischargeAll(ctx context.Context, m *bakery.Macaroon) (macaroon
 	return bakery.DischargeAllWithKey(ctx, m, c.AcquireDischarge, c.Key)
 }
 
+// DischargeAllUnbound is like DischargeAll except that it does not
+// bind the resulting macaroons.
+func (c *Client) DischargeAllUnbound(ctx context.Context, ms bakery.Slice) (bakery.Slice, error) {
+	return ms.DischargeAll(ctx, c.AcquireDischarge, c.Key)
+}
+
 // Do is like DoWithContext, except the context is automatically derived.
 // If using go version 1.7 or later the context will be taken from the
 // given request, otherwise context.Background() will be used.


### PR DESCRIPTION
This makes it easier for a client to store undischarged macaroons,
which are more versatile because caveats can be added and discharges
obtained independently of the primary macaroon.