### PR TITLE
httpbakery: update NewDischargeRequiredError

### DIFF
--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -112,8 +112,11 @@ func (srv *targetServiceHandler) writeError(ctx context.Context, w http.Response
 		return
 	}
 
-	herr := httpbakery.NewDischargeRequiredError(m, "/", derr, req)
-	herr.(*httpbakery.Error).Info.CookieNameSuffix = "auth"
+	herr := httpbakery.NewDischargeRequiredError(httpbakery.DischargeRequiredErrorParams{
+		Macaroon:      m,
+		OriginalError: derr,
+		Request:       req,
+	})
 	httpbakery.WriteError(ctx, w, herr)
 }
 

--- a/httpbakery/agent/legacy_test.go
+++ b/httpbakery/agent/legacy_test.go
@@ -296,7 +296,10 @@ func (s *legacyAgentSuite) visit(p httprequest.Params, dischargeId string, rende
 	if err != nil {
 		return errgo.Notef(err, "cannot create macaroon")
 	}
-	return httpbakery.NewDischargeRequiredError(m, "/", nil, p.Request)
+	return httpbakery.NewDischargeRequiredError(httpbakery.DischargeRequiredErrorParams{
+		Macaroon: m,
+		Request:  p.Request,
+	})
 }
 
 // LegacyAgentHandler represents a handler for legacy

--- a/internal/httputil/relativeurl.go
+++ b/internal/httputil/relativeurl.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Note: this code was copied from github.com/juju/utils.
+
+// Package httputil holds utility functions related to net/http.
+package httputil
+
+import (
+	"errors"
+	"strings"
+)
+
+// RelativeURLPath returns a relative URL path that is lexically
+// equivalent to targpath when interpreted by url.URL.ResolveReference.
+// On success, the returned path will always be non-empty and relative
+// to basePath, even if basePath and targPath share no elements.
+//
+// It is assumed that both basePath and targPath are normalized
+// (have no . or .. elements).
+//
+// An error is returned if basePath or targPath are not absolute paths.
+func RelativeURLPath(basePath, targPath string) (string, error) {
+	if !strings.HasPrefix(basePath, "/") {
+		return "", errors.New("non-absolute base URL")
+	}
+	if !strings.HasPrefix(targPath, "/") {
+		return "", errors.New("non-absolute target URL")
+	}
+	baseParts := strings.Split(basePath, "/")
+	targParts := strings.Split(targPath, "/")
+
+	// For the purposes of dotdot, the last element of
+	// the paths are irrelevant. We save the last part
+	// of the target path for later.
+	lastElem := targParts[len(targParts)-1]
+	baseParts = baseParts[0 : len(baseParts)-1]
+	targParts = targParts[0 : len(targParts)-1]
+
+	// Find the common prefix between the two paths:
+	var i int
+	for ; i < len(baseParts); i++ {
+		if i >= len(targParts) || baseParts[i] != targParts[i] {
+			break
+		}
+	}
+	dotdotCount := len(baseParts) - i
+	targOnly := targParts[i:]
+	result := make([]string, 0, dotdotCount+len(targOnly)+1)
+	for i := 0; i < dotdotCount; i++ {
+		result = append(result, "..")
+	}
+	result = append(result, targOnly...)
+	result = append(result, lastElem)
+	final := strings.Join(result, "/")
+	if final == "" {
+		// If the final result is empty, the last element must
+		// have been empty, so the target was slash terminated
+		// and there were no previous elements, so "."
+		// is appropriate.
+		final = "."
+	}
+	return final, nil
+}

--- a/internal/httputil/relativeurl_test.go
+++ b/internal/httputil/relativeurl_test.go
@@ -1,0 +1,150 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Note: this code was copied from github.com/juju/utils.
+
+package httputil_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/internal/httputil"
+)
+
+var relativeURLTests = []struct {
+	base        string
+	target      string
+	expect      string
+	expectError string
+}{{
+	expectError: "non-absolute base URL",
+}, {
+	base:        "/foo",
+	expectError: "non-absolute target URL",
+}, {
+	base:        "foo",
+	expectError: "non-absolute base URL",
+}, {
+	base:        "/foo",
+	target:      "foo",
+	expectError: "non-absolute target URL",
+}, {
+	base:   "/foo",
+	target: "/bar",
+	expect: "bar",
+}, {
+	base:   "/foo/",
+	target: "/bar",
+	expect: "../bar",
+}, {
+	base:   "/bar",
+	target: "/foo/",
+	expect: "foo/",
+}, {
+	base:   "/foo/",
+	target: "/bar/",
+	expect: "../bar/",
+}, {
+	base:   "/foo/bar",
+	target: "/bar/",
+	expect: "../bar/",
+}, {
+	base:   "/foo/bar/",
+	target: "/bar/",
+	expect: "../../bar/",
+}, {
+	base:   "/foo/bar/baz",
+	target: "/foo/targ",
+	expect: "../targ",
+}, {
+	base:   "/foo/bar/baz/frob",
+	target: "/foo/bar/one/two/",
+	expect: "../one/two/",
+}, {
+	base:   "/foo/bar/baz/",
+	target: "/foo/targ",
+	expect: "../../targ",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar/one/two/",
+	expect: "../../one/two/",
+}, {
+	base:   "/foo/bar",
+	target: "/foot/bar",
+	expect: "../foot/bar",
+}, {
+	base:   "/foo/bar/baz/frob",
+	target: "/foo/bar",
+	expect: "../../bar",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar",
+	expect: "../../../bar",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar/",
+	expect: "../../",
+}, {
+	base:   "/foo/bar/baz",
+	target: "/foo/bar/other",
+	expect: "other",
+}, {
+	base:   "/foo/bar/",
+	target: "/foo/bar/",
+	expect: ".",
+}, {
+	base:   "/foo/bar",
+	target: "/foo/bar",
+	expect: "bar",
+}, {
+	base:   "/foo/bar/",
+	target: "/foo/bar/",
+	expect: ".",
+}, {
+	base:   "/foo/bar",
+	target: "/foo/",
+	expect: ".",
+}, {
+	base:   "/foo",
+	target: "/",
+	expect: ".",
+}, {
+	base:   "/foo/",
+	target: "/",
+	expect: "../",
+}, {
+	base:   "/foo/bar",
+	target: "/",
+	expect: "../",
+}, {
+	base:   "/foo/bar/",
+	target: "/",
+	expect: "../../",
+}}
+
+func TestRelativeURL(t *testing.T) {
+	c := qt.New(t)
+	for i, test := range relativeURLTests {
+		t.Logf("test %d: %q %q", i, test.base, test.target)
+		// Sanity check the test itself.
+		if test.expectError == "" {
+			baseURL := &url.URL{Path: test.base}
+			expectURL := &url.URL{Path: test.expect}
+			targetURL := baseURL.ResolveReference(expectURL)
+			c.Check(targetURL.Path, qt.Equals, test.target, fmt.Sprintf("resolve reference failure (%q + %q != %q)", test.base, test.expect, test.target))
+		}
+
+		result, err := httputil.RelativeURLPath(test.base, test.target)
+		if test.expectError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectError)
+			c.Assert(result, qt.Equals, "")
+		} else {
+			c.Assert(err, qt.IsNil)
+			c.Check(result, qt.Equals, test.expect)
+		}
+	}
+}


### PR DESCRIPTION
The current design stems from the fact that we needed
to keep the API compatible. Now that we have bakery.Macaroon,
we can tell the version from the macaroon that's being returned,
and we can also provide more useful defaults for the cookie
path and its name (the current default of creating a separate cookie
for every macaroon is not such a great idea).

This is an API-breaking change.