### PR TITLE
httpbakery: add Oven type

### DIFF
--- a/bakery/slice.go
+++ b/bakery/slice.go
@@ -2,12 +2,13 @@ package bakery
 
 import (
 	"fmt"
-	"golang.org/x/net/context"
 	"time"
 
+	"golang.org/x/net/context"
 	errgo "gopkg.in/errgo.v1"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	macaroon "gopkg.in/macaroon.v2-unstable"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 )
 
 // Slice holds a slice of unbound macaroons.

--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -31,6 +31,7 @@ const (
 	ErrDischargeRequired         = ErrorCode("macaroon discharge required")
 	ErrInteractionRequired       = ErrorCode("interaction required")
 	ErrInteractionMethodNotFound = ErrorCode("discharger does not provide an supported interaction method")
+	ErrPermissionDenied          = ErrorCode("permission denied")
 )
 
 var httpReqServer = httprequest.Server{
@@ -170,6 +171,8 @@ func ErrorToResponse(ctx context.Context, err error) (int, interface{}) {
 	switch errorBody.Code {
 	case ErrBadRequest:
 		status = http.StatusBadRequest
+	case ErrPermissionDenied:
+		status = http.StatusUnauthorized
 	case ErrDischargeRequired, ErrInteractionRequired:
 		switch errorBody.version {
 		case bakery.Version0:
@@ -211,6 +214,7 @@ func errorResponseBody(err error) *Error {
 		errResp.Message = err.Error()
 		return &errResp
 	}
+
 	// It's not an error. Preserve as much info as
 	// we can find.
 	errResp.Message = err.Error()

--- a/httpbakery/oven.go
+++ b/httpbakery/oven.go
@@ -1,0 +1,84 @@
+package httpbakery
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/net/context"
+	errgo "gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+)
+
+// Oven is like bakery.Oven except it provides a method for
+// translating errors returned by bakery.AuthChecker into
+// errors suitable for passing to WriteError.
+type Oven struct {
+	// Oven holds the bakery Oven used to create
+	// new macaroons to put in discharge-required errors.
+	*bakery.Oven
+
+	// AuthnExpiry holds the expiry time of macaroons that
+	// are created for authentication. As these are generally
+	// applicable to all endpoints in an API, this is usually
+	// longer than AuthzExpiry. If this is zero, DefaultAuthnExpiry
+	// will be used.
+	AuthnExpiry time.Duration
+
+	// AuthzExpiry holds the expiry time of macaroons that are
+	// created for authorization. As these are generally applicable
+	// to specific operations, they generally don't need
+	// a long lifespan, so this is usually shorter than AuthnExpiry.
+	// If this is zero, DefaultAuthzExpiry will be used.
+	AuthzExpiry time.Duration
+}
+
+// Default expiry times for macaroons created by Oven.Error.
+const (
+	DefaultAuthnExpiry = 7 * 24 * time.Hour
+	DefaultAuthzExpiry = 5 * time.Minute
+)
+
+// Error processes an error as returned from bakery.AuthChecker
+// into an error suitable for returning as a response to req
+// with WriteError.
+//
+// Specifically, it translates bakery.ErrPermissionDenied into
+// ErrPermissionDenied and bakery.DischargeRequiredError
+// into an Error with an ErrDischargeRequired code, using
+// oven.Oven to mint the macaroon in it.
+func (oven *Oven) Error(ctx context.Context, req *http.Request, err error) error {
+	cause := errgo.Cause(err)
+	if cause == bakery.ErrPermissionDenied {
+		return errgo.WithCausef(err, ErrPermissionDenied, "")
+	}
+	derr, ok := cause.(*bakery.DischargeRequiredError)
+	if !ok {
+		return errgo.Mask(err)
+	}
+	// TODO it's possible to have more than two levels here - think
+	// about some naming scheme for the cookies that allows that.
+	expiryDuration := oven.AuthzExpiry
+	if expiryDuration == 0 {
+		expiryDuration = DefaultAuthzExpiry
+	}
+	cookieName := "authz"
+	if len(derr.Ops) == 1 && derr.Ops[0] == bakery.LoginOp {
+		// Authentication macaroons are a bit different, so use
+		// a different cookie name so both can be presented together.
+		cookieName = "authn"
+		expiryDuration = oven.AuthnExpiry
+		if expiryDuration == 0 {
+			expiryDuration = DefaultAuthnExpiry
+		}
+	}
+	m, err := oven.Oven.NewMacaroon(ctx, RequestVersion(req), time.Now().Add(expiryDuration), derr.Caveats, derr.Ops...)
+	if err != nil {
+		return errgo.Notef(err, "cannot mint new macaroon")
+	}
+	return NewDischargeRequiredError(DischargeRequiredErrorParams{
+		Macaroon:         m,
+		CookieNameSuffix: cookieName,
+		Request:          req,
+	})
+}

--- a/httpbakery/oven_test.go
+++ b/httpbakery/oven_test.go
@@ -1,0 +1,185 @@
+package httpbakery_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/juju/httprequest"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+)
+
+type OvenSuite struct {
+	jujutesting.LoggingSuite
+}
+
+var _ = gc.Suite(&OvenSuite{})
+
+func (*OvenSuite) TestOvenWithAuthnMacaroon(c *gc.C) {
+	discharger := newTestIdentityServer()
+	defer discharger.Close()
+
+	key, err := bakery.GenerateKey()
+	if err != nil {
+		panic(err)
+	}
+	b := bakery.New(bakery.BakeryParams{
+		Location:       "here",
+		Locator:        discharger,
+		Key:            key,
+		Checker:        httpbakery.NewChecker(),
+		IdentityClient: discharger,
+	})
+	expectedExpiry := time.Hour
+	oven := &httpbakery.Oven{
+		Oven:        b.Oven,
+		AuthnExpiry: expectedExpiry,
+		AuthzExpiry: 5 * time.Minute,
+	}
+	errorCalled := 0
+	handler := httpReqServer.HandleErrors(func(p httprequest.Params) error {
+		if _, err := b.Checker.Auth(httpbakery.RequestMacaroons(p.Request)...).Allow(p.Context, bakery.LoginOp); err != nil {
+			errorCalled++
+			return oven.Error(testContext, p.Request, err)
+		}
+		fmt.Fprintf(p.Response, "done")
+		return nil
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler(w, req, nil)
+	}))
+	defer ts.Close()
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	c.Assert(err, gc.Equals, nil)
+	client := httpbakery.NewClient()
+	t0 := time.Now()
+	resp, err := client.Do(req)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(errorCalled, gc.Equals, 1)
+	body, _ := ioutil.ReadAll(resp.Body)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK, gc.Commentf("body: %q", body))
+	mss := httpbakery.MacaroonsForURL(client.Jar, mustParseURL(discharger.Location()))
+	c.Assert(mss, gc.HasLen, 1)
+	t, ok := checkers.MacaroonsExpiryTime(b.Checker.Namespace(), mss[0])
+	c.Assert(ok, gc.Equals, true)
+	want := t0.Add(expectedExpiry)
+	c.Assert(t, jc.TimeBetween(want, want.Add(time.Second)))
+}
+
+func (*OvenSuite) TestOvenWithAuthzMacaroon(c *gc.C) {
+	discharger := newTestIdentityServer()
+	defer discharger.Close()
+	discharger2 := bakerytest.NewDischarger(nil)
+	defer discharger2.Close()
+
+	locator := httpbakery.NewThirdPartyLocator(nil, nil)
+	locator.AllowInsecure()
+
+	key, err := bakery.GenerateKey()
+	if err != nil {
+		panic(err)
+	}
+	b := bakery.New(bakery.BakeryParams{
+		Location:       "here",
+		Locator:        locator,
+		Key:            key,
+		Checker:        httpbakery.NewChecker(),
+		IdentityClient: discharger,
+		Authorizer: bakery.AuthorizerFunc(func(ctx context.Context, id bakery.Identity, op bakery.Op) (bool, []checkers.Caveat, error) {
+			return true, []checkers.Caveat{{
+				Location:  discharger2.Location(),
+				Condition: "something",
+			}}, nil
+		}),
+	})
+	expectedAuthnExpiry := 5 * time.Minute
+	expectedAuthzExpiry := time.Hour
+	oven := &httpbakery.Oven{
+		Oven:        b.Oven,
+		AuthnExpiry: expectedAuthnExpiry,
+		AuthzExpiry: expectedAuthzExpiry,
+	}
+	errorCalled := 0
+	handler := httpReqServer.HandleErrors(func(p httprequest.Params) error {
+		if _, err := b.Checker.Auth(httpbakery.RequestMacaroons(p.Request)...).Allow(p.Context, bakery.Op{"something", "read"}); err != nil {
+			errorCalled++
+			return oven.Error(testContext, p.Request, err)
+		}
+		fmt.Fprintf(p.Response, "done")
+		return nil
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler(w, req, nil)
+	}))
+	defer ts.Close()
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	c.Assert(err, gc.Equals, nil)
+	client := httpbakery.NewClient()
+	t0 := time.Now()
+	resp, err := client.Do(req)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(errorCalled, gc.Equals, 2)
+	body, _ := ioutil.ReadAll(resp.Body)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK, gc.Commentf("body: %q", body))
+
+	mss := httpbakery.MacaroonsForURL(client.Jar, mustParseURL(discharger.Location()))
+	c.Assert(mss, gc.HasLen, 2)
+
+	// The cookie jar returns otherwise-similar cookies in the order
+	// they were added, so the authn macaroon will be first.
+	t, ok := checkers.MacaroonsExpiryTime(b.Checker.Namespace(), mss[0])
+	c.Assert(ok, gc.Equals, true)
+	want := t0.Add(expectedAuthnExpiry)
+	c.Assert(t, jc.TimeBetween(want, want.Add(time.Second)))
+
+	t, ok = checkers.MacaroonsExpiryTime(b.Checker.Namespace(), mss[1])
+	c.Assert(ok, gc.Equals, true)
+	want = t0.Add(expectedAuthzExpiry)
+	c.Assert(t, jc.TimeBetween(want, want.Add(time.Second)))
+}
+
+type testIdentityServer struct {
+	*bakerytest.Discharger
+}
+
+func newTestIdentityServer() *testIdentityServer {
+	checker := func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo, token *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
+		if string(cav.Condition) != "is-authenticated-user" {
+			return nil, errgo.New("unexpected caveat")
+		}
+		return []checkers.Caveat{
+			checkers.DeclaredCaveat("username", "bob"),
+		}, nil
+	}
+	discharger := bakerytest.NewDischarger(nil)
+	discharger.Checker = httpbakery.ThirdPartyCaveatCheckerFunc(checker)
+	return &testIdentityServer{
+		Discharger: discharger,
+	}
+}
+
+func (s *testIdentityServer) IdentityFromContext(ctx context.Context) (bakery.Identity, []checkers.Caveat, error) {
+	return nil, []checkers.Caveat{{
+		Location:  s.Location(),
+		Condition: "is-authenticated-user",
+	}}, nil
+}
+
+func (s *testIdentityServer) DeclaredIdentity(ctx context.Context, declared map[string]string) (bakery.Identity, error) {
+	username, ok := declared["username"]
+	if !ok {
+		return nil, errgo.New("no username declared")
+	}
+	return bakery.SimpleIdentity(username), nil
+}


### PR DESCRIPTION
This implements some functionality which almost every HTTP server
using the bakery will need - to translate from bakery.DischargeRequiredError
to the discharge-required error as returned from httpbakery.