### PR TITLE
bakery: remove expiry time from Oven.NewMacaroon

### DIFF
--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -22,7 +22,6 @@ var logger = loggo.GetLogger("bakery.bakery_test")
 
 var (
 	epoch = time.Date(1900, 11, 17, 19, 00, 13, 0, time.UTC)
-	ages  = epoch.Add(24 * time.Hour)
 )
 
 var testChecker = func() *checkers.Checker {

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -28,7 +28,7 @@ var _ = gc.Suite(&ServiceSuite{})
 func (s *ServiceSuite) TestSingleServiceFirstParty(c *gc.C) {
 	oc := newBakery("bakerytest", nil)
 
-	primary, err := oc.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, bakery.LoginOp)
+	primary, err := oc.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 	c.Assert(primary.M().Location(), gc.Equals, "bakerytest")
 	err = oc.Oven.AddCaveat(testContext, primary, strCaveat("something"))
@@ -54,7 +54,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6(c *gc.C) {
 	fs := newBakery("fs-loc", locator)
 
 	// ts creates a macaroon.
-	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, bakery.LoginOp)
+	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 
 	// ts somehow sends the macaroon to fs which adds a third party caveat to be discharged by as.
@@ -79,7 +79,7 @@ func (s *ServiceSuite) TestDischargeWithVersion1Macaroon(c *gc.C) {
 	ts := newBakery("ts-loc", locator)
 
 	// ts creates a old-version macaroon.
-	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.Version1, ages, nil, bakery.LoginOp)
+	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.Version1, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 	err = ts.Oven.AddCaveat(testContext, tsMacaroon, checkers.Caveat{Location: "as-loc", Condition: "something"})
 	c.Assert(err, gc.IsNil)
@@ -131,7 +131,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithoutDischarges(c *gc.C) {
 	newBakery("as-loc", locator)
 
 	// ts creates a macaroon.
-	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, bakery.LoginOp)
+	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 
 	// ts somehow sends the macaroon to fs which adds a third party caveat to be discharged by as.
@@ -152,7 +152,7 @@ func (s *ServiceSuite) TestMacaroonPaperFig6FailsWithBindingOnTamperedSignature(
 	fs := newBakery("fs-loc", locator)
 
 	// ts creates a macaroon.
-	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, bakery.LoginOp)
+	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 
 	// ts somehow sends the macaroon to fs which adds a third party caveat to be discharged by as.
@@ -195,7 +195,7 @@ func (s *ServiceSuite) TestNeedDeclared(c *gc.C) {
 
 	// firstParty mints a macaroon with a third-party caveat addressed
 	// to thirdParty with a need-declared caveat.
-	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
+	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{
 		checkers.NeedDeclaredCaveat(checkers.Caveat{
 			Location:  "third",
 			Condition: "something",
@@ -285,7 +285,7 @@ func (s *ServiceSuite) TestDischargeTwoNeedDeclared(c *gc.C) {
 
 	// firstParty mints a macaroon with two third party caveats
 	// with overlapping attributes.
-	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
+	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{
 		checkers.NeedDeclaredCaveat(checkers.Caveat{
 			Location:  "third",
 			Condition: "x",
@@ -355,7 +355,7 @@ func (s *ServiceSuite) TestDischargeMacaroonCannotBeUsedAsNormalMacaroon(c *gc.C
 	thirdParty := newBakery("third", locator)
 
 	// First party mints a macaroon with a 3rd party caveat.
-	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := firstParty.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{{
 		Location:  "third",
 		Condition: "true",
 	}}, bakery.LoginOp)
@@ -387,7 +387,7 @@ func (s *ServiceSuite) TestThirdPartyDischargeMacaroonIdsAreSmall(c *gc.C) {
 	}
 	ts := bakeries["ts-loc"]
 
-	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, bakery.LoginOp)
+	tsMacaroon, err := ts.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
 	err = ts.Oven.AddCaveat(testContext, tsMacaroon, checkers.Caveat{Location: "as1-loc", Condition: "something"})
 	c.Assert(err, gc.IsNil)

--- a/bakery/dischargeall_test.go
+++ b/bakery/dischargeall_test.go
@@ -136,7 +136,7 @@ func (*DischargeSuite) TestDischargeAllLocalDischarge(c *gc.C) {
 	clientKey, err := bakery.GenerateKey()
 	c.Assert(err, gc.IsNil)
 
-	m, err := oc.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
+	m, err := oc.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(&clientKey.Public, bakery.LatestVersion),
 	}, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)
@@ -154,7 +154,7 @@ func (*DischargeSuite) TestDischargeAllLocalDischargeVersion1(c *gc.C) {
 	clientKey, err := bakery.GenerateKey()
 	c.Assert(err, gc.IsNil)
 
-	m, err := oc.Oven.NewMacaroon(testContext, bakery.Version1, ages, []checkers.Caveat{
+	m, err := oc.Oven.NewMacaroon(testContext, bakery.Version1, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(&clientKey.Public, bakery.Version1),
 	}, bakery.LoginOp)
 	c.Assert(err, gc.IsNil)

--- a/bakery/oven_test.go
+++ b/bakery/oven_test.go
@@ -56,11 +56,11 @@ func (*ovenSuite) TestCanonicalOps(c *gc.C) {
 func (*ovenSuite) TestMultipleOps(c *gc.C) {
 	oven := bakery.NewOven(bakery.OvenParams{})
 	ops := []bakery.Op{{"one", "read"}, {"one", "write"}, {"two", "read"}}
-	m, err := oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, ops...)
+	m, err := oven.NewMacaroon(testContext, bakery.LatestVersion, nil, ops...)
 	c.Assert(err, gc.IsNil)
 	gotOps, conds, err := oven.VerifyMacaroon(testContext, macaroon.Slice{m.M()})
 	c.Assert(err, gc.IsNil)
-	c.Assert(conds, gc.HasLen, 1) // time-before caveat.
+	c.Assert(conds, gc.HasLen, 0)
 	c.Assert(bakery.CanonicalOps(gotOps), jc.DeepEquals, ops)
 }
 
@@ -68,11 +68,11 @@ func (*ovenSuite) TestMultipleOpsInId(c *gc.C) {
 	oven := bakery.NewOven(bakery.OvenParams{})
 
 	ops := []bakery.Op{{"one", "read"}, {"one", "write"}, {"two", "read"}}
-	m, err := oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, ops...)
+	m, err := oven.NewMacaroon(testContext, bakery.LatestVersion, nil, ops...)
 	c.Assert(err, gc.IsNil)
 	gotOps, conds, err := oven.VerifyMacaroon(testContext, macaroon.Slice{m.M()})
 	c.Assert(err, gc.IsNil)
-	c.Assert(conds, gc.HasLen, 1) // time-before caveat.
+	c.Assert(conds, gc.HasLen, 0)
 	c.Assert(bakery.CanonicalOps(gotOps), jc.DeepEquals, ops)
 }
 
@@ -80,10 +80,10 @@ func (*ovenSuite) TestMultipleOpsInIdWithVersion1(c *gc.C) {
 	oven := bakery.NewOven(bakery.OvenParams{})
 
 	ops := []bakery.Op{{"one", "read"}, {"one", "write"}, {"two", "read"}}
-	m, err := oven.NewMacaroon(testContext, bakery.Version1, ages, nil, ops...)
+	m, err := oven.NewMacaroon(testContext, bakery.Version1, nil, ops...)
 	c.Assert(err, gc.IsNil)
 	gotOps, conds, err := oven.VerifyMacaroon(testContext, macaroon.Slice{m.M()})
 	c.Assert(err, gc.IsNil)
-	c.Assert(conds, gc.HasLen, 1) // time-before caveat.
+	c.Assert(conds, gc.HasLen, 0)
 	c.Assert(bakery.CanonicalOps(gotOps), jc.DeepEquals, ops)
 }

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -32,10 +32,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 
 var _ = gc.Suite(&suite{})
 
-var (
-	ages        = time.Now().Add(time.Hour)
-	dischargeOp = bakery.Op{"thirdparty", "x"}
-)
+var dischargeOp = bakery.Op{"thirdparty", "x"}
 
 func (s *suite) TestDischargerSimple(c *gc.C) {
 	d := bakerytest.NewDischarger(nil)
@@ -46,7 +43,7 @@ func (s *suite) TestDischargerSimple(c *gc.C) {
 		Locator:  d,
 		Key:      bakery.MustGenerateKey(),
 	})
-	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}}, dischargeOp)
@@ -93,7 +90,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 		Locator:  locator,
 		Key:      bakery.MustGenerateKey(),
 	})
-	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d2.Location(),
 		Condition: "true",
 	}}, dischargeOp)
@@ -192,7 +189,7 @@ func (s *suite) TestInteractiveDischarger(c *gc.C) {
 		Checker:  &r,
 		Key:      bakery.MustGenerateKey(),
 	})
-	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}}, dischargeOp)
@@ -208,8 +205,8 @@ func (s *suite) TestInteractiveDischarger(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	// First caveat is time-before caveat added by NewMacaroon.
 	// Second is the one added by the discharger above.
-	c.Assert(r.caveats, gc.HasLen, 2)
-	c.Assert(r.caveats[1], gc.Equals, "test pass")
+	c.Assert(r.caveats, gc.HasLen, 1)
+	c.Assert(r.caveats[0], gc.Equals, "test pass")
 
 	c.Check(visited, gc.Equals, true)
 	c.Check(waited, gc.Equals, true)
@@ -249,7 +246,7 @@ func (s *suite) TestLoginDischargerError(c *gc.C) {
 		Locator:  d,
 		Key:      bakery.MustGenerateKey(),
 	})
-	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}}, dischargeOp)
@@ -304,7 +301,7 @@ func (s *suite) TestInteractiveDischargerRedirection(c *gc.C) {
 		Key:      bakery.MustGenerateKey(),
 		Checker:  &r,
 	})
-	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}}, dischargeOp)
@@ -320,9 +317,7 @@ func (s *suite) TestInteractiveDischargerRedirection(c *gc.C) {
 	_, err = b.Checker.Auth(ms).Allow(context.Background(), dischargeOp)
 	c.Assert(err, gc.IsNil)
 
-	// Note: the first caveat is the "time-before" caveat
-	// that's always created.
-	c.Assert(r.caveats[1:], gc.DeepEquals, []string{"condition"})
+	c.Assert(r.caveats, gc.DeepEquals, []string{"condition"})
 }
 
 type recordingChecker struct {

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -2,7 +2,6 @@ package agent_test
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/juju/httprequest"
 	"github.com/juju/testing"
@@ -59,7 +58,6 @@ func (s *agentSuite) TestSetUpAuth(c *gc.C) {
 			return dischargerBakery.Oven.NewMacaroon(
 				context.Background(),
 				bakery.LatestVersion,
-				time.Now().Add(time.Minute),
 				[]checkers.Caveat{
 					bakery.LocalThirdPartyCaveat(pubKey, version),
 				},
@@ -106,7 +104,6 @@ func (s *agentSuite) TestSetUpAuth(c *gc.C) {
 	m, err := s.serverBakery.Oven.NewMacaroon(
 		context.Background(),
 		bakery.LatestVersion,
-		time.Now().Add(time.Minute),
 		[]checkers.Caveat{{
 			Location:  s.discharger.Location(),
 			Condition: "some-third-party-caveat",

--- a/httpbakery/agent/legacy_test.go
+++ b/httpbakery/agent/legacy_test.go
@@ -121,7 +121,6 @@ func (s *legacyAgentSuite) TestAgentLoginError(c *gc.C) {
 		m, err := s.serverBakery.Oven.NewMacaroon(
 			context.Background(),
 			bakery.LatestVersion,
-			time.Now().Add(time.Minute),
 			identityCaveats(s.discharger.Location()),
 			bakery.LoginOp,
 		)
@@ -175,7 +174,6 @@ func (s *legacyAgentSuite) TestSetUpAuth(c *gc.C) {
 	m, err := s.serverBakery.Oven.NewMacaroon(
 		context.Background(),
 		bakery.LatestVersion,
-		time.Now().Add(time.Minute),
 		identityCaveats(s.discharger.Location()),
 		bakery.LoginOp,
 	)
@@ -228,7 +226,6 @@ func (s *legacyAgentSuite) TestNoMatchingSite(c *gc.C) {
 	m, err := s.serverBakery.Oven.NewMacaroon(
 		context.Background(),
 		bakery.LatestVersion,
-		time.Now().Add(time.Minute),
 		identityCaveats(s.discharger.Location()),
 		bakery.LoginOp,
 	)
@@ -259,8 +256,6 @@ func (c idmClient) DeclaredIdentity(ctx context.Context, declared map[string]str
 	return bakery.SimpleIdentity(declared["username"]), nil
 }
 
-var ages = time.Now().Add(time.Hour)
-
 // handleLoginMethods handles a legacy visit request
 // to ask for the set of login methods.
 // It reports whether it has handled the request.
@@ -289,7 +284,7 @@ func (s *legacyAgentSuite) visit(p httprequest.Params, dischargeId string, rende
 		return nil
 	}
 	version := httpbakery.RequestVersion(p.Request)
-	m, err := s.agentBakery.Oven.NewMacaroon(ctx, version, ages, []checkers.Caveat{
+	m, err := s.agentBakery.Oven.NewMacaroon(ctx, version, []checkers.Caveat{
 		bakery.LocalThirdPartyCaveat(userPublicKey, version),
 		checkers.DeclaredCaveat("username", username),
 	}, bakery.LoginOp)

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -37,7 +37,6 @@ var _ = gc.Suite(&ClientSuite{})
 
 var (
 	testOp      = bakery.Op{"test", "test"}
-	ages        = time.Now().Add(24 * time.Hour)
 	testContext = context.Background()
 )
 
@@ -58,7 +57,7 @@ func (s *ClientSuite) TestSingleServiceFirstParty(c *gc.C) {
 	defer ts.Close()
 
 	// Mint a macaroon for the target service.
-	serverMacaroon, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, testOp)
+	serverMacaroon, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, testOp)
 	c.Assert(err, gc.IsNil)
 	c.Assert(serverMacaroon.M().Location(), gc.Equals, "loc")
 	err = b.Oven.AddCaveat(testContext, serverMacaroon, isSomethingCaveat())
@@ -90,7 +89,7 @@ func (s *ClientSuite) TestSingleServiceFirstPartyWithHeader(c *gc.C) {
 	defer ts.Close()
 
 	// Mint a macaroon for the target service.
-	serverMacaroon, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, testOp)
+	serverMacaroon, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, testOp)
 	c.Assert(err, gc.IsNil)
 	c.Assert(serverMacaroon.M().Location(), gc.Equals, "loc")
 	err = b.Oven.AddCaveat(testContext, serverMacaroon, isSomethingCaveat())
@@ -437,7 +436,7 @@ func (s *ClientSuite) serverRequiringMultipleDischarges(n int, discharger *baker
 				Condition: fmt.Sprintf("error %d attempts left", n),
 			})
 		}
-		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, ages, caveats, testOp)
+		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, caveats, testOp)
 		if err != nil {
 			panic(fmt.Errorf("cannot make new macaroon: %v", err))
 		}
@@ -1011,9 +1010,9 @@ func (s *ClientSuite) TestMacaroonsForURL(c *gc.C) {
 	// Create a target service.
 	b := newBakery("loc", nil, nil)
 
-	m1, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, testOp)
+	m1, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, testOp)
 	c.Assert(err, gc.IsNil)
-	m2, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, nil, testOp)
+	m2, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, nil, testOp)
 	c.Assert(err, gc.IsNil)
 
 	u1 := mustParseURL("http://0.1.2.3/")
@@ -1133,7 +1132,7 @@ func (s *ClientSuite) TestHandleError(c *gc.C) {
 	}))
 	defer srv.Close()
 
-	m, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{{
+	m, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{{
 		Location:  d.Location(),
 		Condition: "something",
 	}}, testOp)
@@ -1209,7 +1208,7 @@ func (s *ClientSuite) TestHandleErrorDifferentError(c *gc.C) {
 func (s *ClientSuite) TestNewCookieExpires(c *gc.C) {
 	t := time.Now().Add(time.Minute)
 	b := newBakery("loc", nil, nil)
-	m, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, []checkers.Caveat{
+	m, err := b.Oven.NewMacaroon(testContext, bakery.LatestVersion, []checkers.Caveat{
 		checkers.TimeBeforeCaveat(t),
 	}, testOp)
 
@@ -1381,7 +1380,7 @@ func newDischargeRequiredError(hp serverHandlerParams, checkErr error, req *http
 	if hp.caveats != nil {
 		caveats = append(caveats, hp.caveats()...)
 	}
-	m, err := hp.bakery.Oven.NewMacaroon(testContext, bakery.LatestVersion, ages, caveats, testOp)
+	m, err := hp.bakery.Oven.NewMacaroon(testContext, bakery.LatestVersion, caveats, testOp)
 	if err != nil {
 		panic(fmt.Errorf("cannot make new macaroon: %v", err))
 	}

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -2,7 +2,6 @@ package form_test
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/juju/httprequest"
 	jujutesting "github.com/juju/testing"
@@ -23,8 +22,6 @@ import (
 type formSuite struct {
 	jujutesting.LoggingSuite
 }
-
-var ages = time.Now().Add(time.Hour)
 
 var reqServer = httprequest.Server{
 	ErrorMapper: httpbakery.ErrorToResponse,
@@ -142,7 +139,7 @@ func (s *formSuite) TestFormLogin(c *gc.C) {
 		postForm = test.postForm
 		noFormMethod = test.noFormMethod
 
-		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, ages, []checkers.Caveat{{
+		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, []checkers.Caveat{{
 			Location:  discharger.Location(),
 			Condition: "test condition",
 		}}, bakery.LoginOp)
@@ -213,7 +210,7 @@ func (s *formSuite) TestFormTitle(c *gc.C) {
 	})
 	for i, test := range formTitleTests {
 		c.Logf("test %d: %s", i, test.host)
-		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, ages, []checkers.Caveat{{
+		m, err := b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, []checkers.Caveat{{
 			Location:  "https://" + test.host,
 			Condition: "test condition",
 		}}, bakery.LoginOp)


### PR DESCRIPTION
This is no longer needed, and was always a bit of a pain
and hard to explain, so remove it.