### PR TITLE
internal/httputil: use gopkg.in/check.v1

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,6 +1,4 @@
-github.com/frankban/quicktest	git	fe41ed117766719e2d387ef4dfd9b12846de9da9	2017-09-21T13:10:42Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
-github.com/google/go-cmp	git	8099a9787ce5dc5984ed879a3bda47dc730a8e97	2017-08-03T17:35:09Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/httprequest	git	77d36ac4b71a6095506c0617d5881846478558cb	2017-10-18T13:24:17Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z

--- a/internal/httputil/package_test.go
+++ b/internal/httputil/package_test.go
@@ -1,0 +1,11 @@
+package httputil_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/httputil/relativeurl_test.go
+++ b/internal/httputil/relativeurl_test.go
@@ -6,14 +6,16 @@
 package httputil_test
 
 import (
-	"fmt"
 	"net/url"
-	"testing"
 
-	qt "github.com/frankban/quicktest"
+	gc "gopkg.in/check.v1"
 
 	"gopkg.in/macaroon-bakery.v2-unstable/internal/httputil"
 )
+
+type relativeURLSuite struct{}
+
+var _ = gc.Suite(&relativeURLSuite{})
 
 var relativeURLTests = []struct {
 	base        string
@@ -126,25 +128,24 @@ var relativeURLTests = []struct {
 	expect: "../../",
 }}
 
-func TestRelativeURL(t *testing.T) {
-	c := qt.New(t)
+func (*relativeURLSuite) TestRelativeURL(c *gc.C) {
 	for i, test := range relativeURLTests {
-		t.Logf("test %d: %q %q", i, test.base, test.target)
+		c.Logf("test %d: %q %q", i, test.base, test.target)
 		// Sanity check the test itself.
 		if test.expectError == "" {
 			baseURL := &url.URL{Path: test.base}
 			expectURL := &url.URL{Path: test.expect}
 			targetURL := baseURL.ResolveReference(expectURL)
-			c.Check(targetURL.Path, qt.Equals, test.target, fmt.Sprintf("resolve reference failure (%q + %q != %q)", test.base, test.expect, test.target))
+			c.Check(targetURL.Path, gc.Equals, test.target, gc.Commentf("resolve reference failure (%q + %q != %q)", test.base, test.expect, test.target))
 		}
 
 		result, err := httputil.RelativeURLPath(test.base, test.target)
 		if test.expectError != "" {
-			c.Assert(err, qt.ErrorMatches, test.expectError)
-			c.Assert(result, qt.Equals, "")
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(result, gc.Equals, "")
 		} else {
-			c.Assert(err, qt.IsNil)
-			c.Check(result, qt.Equals, test.expect)
+			c.Assert(err, gc.IsNil)
+			c.Check(result, gc.Equals, test.expect)
 		}
 	}
 }


### PR DESCRIPTION
This removes the quicktest dependency, as suggested by @mhilton.