### PR TITLE
httpbakery/agent: use POST not GET for agent login

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,7 +5,7 @@ github.com/juju/postgrestest	git	15b53a8afa18fffe65e14c1f297275aa945359c0	2017-1
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
-github.com/juju/utils	git	0bc947b1f4d7c8222d5ad05398e660ef25092ebd	2017-10-08T20:56:56Z
+github.com/juju/utils	git	4d9b38694f1e441c16421e2320f2b2fbd97fa597	2017-11-22T09:36:53Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
@@ -20,4 +20,4 @@ gopkg.in/httprequest.v1	git	fdaf1bffa25560ba0920e3e29aae85d3677ab32e	2017-12-12T
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/macaroon.v2	git	bed2a428da6e56d950bed5b41fcbae3141e5b0d0	2017-10-17T15:30:37Z
 gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z
-gopkg.in/yaml.v2	git	a3f3340b5840cee44f372bddb5880fcbc419b46a	2017-02-08T14:18:51Z
+gopkg.in/yaml.v2	git	1244d3ce02e3e1c16820ada0bae506b6c479f106	2018-01-08T13:15:54Z


### PR DESCRIPTION
When the client doesn't use the shortcut agent login
method (because it's not setting an agent-login cookie
for every request), the protocol is somewhat different.
We use a POST, not a GET, and the field names have changed.

Unfortunately this is challenging to write a decent unit
test for, as the unit test inevitably assumes the protocol
that we're testing against.

To QA, add an agent user to https://api.staging.jujucharms.com/identity
with:

	user-admin put-agent --agent-file $HOME/.agent/testagent.agent --idm-url https://api.staging.jujucharms.com/identity $agentname

Update github.com/rogpeppe/bhttp to use this PR as a dependency.

	bhttp --agent $agentfile https://api.staging.jujucharms.com/identity/v1/whoami

