### PR TITLE
bakery/dbrootkeystore: new package

### DIFF
--- a/bakery/dbrootkeystore/package_test.go
+++ b/bakery/dbrootkeystore/package_test.go
@@ -1,0 +1,11 @@
+package dbrootkeystore_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/bakery/dbrootkeystore/rootkey.go
+++ b/bakery/dbrootkeystore/rootkey.go
@@ -1,0 +1,360 @@
+// Package dbkeystore provides the underlying basis for a bakery.RootKeyStore
+// that uses a database as a persistent store and provides flexible policies
+// for root key storage lifetime.
+package dbrootkeystore
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+	"golang.org/x/net/context"
+	"gopkg.in/errgo.v1"
+
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+var logger = loggo.GetLogger("bakery.dbrootkeystore")
+
+// maxPolicyCache holds the maximum number of store policies that can
+// hold cached keys in a given RootKeys instance.
+//
+// 100 is probably overkill, given that practical systems will
+// likely only have a small number of active policies on any given
+// macaroon collection.
+const maxPolicyCache = 100
+
+// RootKeys represents a cache of macaroon root keys.
+type RootKeys struct {
+	maxCacheSize int
+	clock        Clock
+
+	// TODO (rogpeppe) use RWMutex instead of Mutex here so that
+	// it's faster in the probably-common case that we
+	// have many contended readers.
+	mu       sync.Mutex
+	oldCache map[string]RootKey
+	cache    map[string]RootKey
+
+	// current holds the current root key for each store policy.
+	current map[Policy]RootKey
+}
+
+// Clock can be used to provide a mockable time
+// of day for testing.
+type Clock interface {
+	Now() time.Time
+}
+
+// Backing holds the interface used to store keys in the underlying
+// database used as a backing store by RootKeyStore.
+type Backing interface {
+	// GetKey gets the key with the given id from the
+	// backing store. If the key is not found, it should
+	// return an error with a bakery.ErrNotFound cause.
+	GetKey(id []byte) (RootKey, error)
+
+	// FindLatestKey returns the most recently created root key k
+	// such that all of the following conditions hold:
+	//
+	// 	k.Created >= createdAfter
+	//	k.Expires >= expiresAfter
+	//	k.Expires <= expiresBefore
+	//
+	// If no such key was found, the zero root key should be returned
+	// with a nil error.
+	FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (RootKey, error)
+
+	// InsertKey inserts the given root key into the backing store.
+	// It may return an error if the id or key already exist.
+	InsertKey(key RootKey) error
+}
+
+// RootKey is the type stored in the underlying database.
+type RootKey struct {
+	// Id holds the id of the root key.
+	Id []byte `bson:"_id"`
+	// Created holds the time that the root key was created.
+	Created time.Time
+	// Expires holds the time that the root key expires.
+	Expires time.Time
+	// RootKey holds the root key secret itself.
+	RootKey []byte
+}
+
+// IsValid reports whether the root key contains a key. Note that we
+// always generate non-empty root keys, so we use this to find
+// whether the root key is empty or not.
+func (rk RootKey) IsValid() bool {
+	return rk.RootKey != nil
+}
+
+// IsValidWithPolicy reports whether the given root key
+// is valid to use at the given time with the given store policy.
+func (rk RootKey) IsValidWithPolicy(p Policy, now time.Time) bool {
+	if !rk.IsValid() {
+		return false
+	}
+	return afterEq(rk.Created, now.Add(-p.GenerateInterval)) &&
+		afterEq(rk.Expires, now.Add(p.ExpiryDuration)) &&
+		beforeEq(rk.Expires, now.Add(p.ExpiryDuration+p.GenerateInterval))
+}
+
+// NewRootKeys returns a root-keys cache that
+// is limited in size to approximately the given size.
+//
+// The NewStore method returns a store implementation
+// that uses specific store policy and backing database
+// implementation.
+//
+// If clock is non-nil, it will be used to find the current
+// time, otherwise time.Now will be used.
+func NewRootKeys(maxCacheSize int, clock Clock) *RootKeys {
+	if clock == nil {
+		clock = wallClock{}
+	}
+	return &RootKeys{
+		maxCacheSize: maxCacheSize,
+		cache:        make(map[string]RootKey),
+		current:      make(map[Policy]RootKey),
+		clock:        clock,
+	}
+}
+
+// Policy holds a store policy for root keys.
+type Policy struct {
+	// GenerateInterval holds the maximum length of time
+	// for which a root key will be returned from RootKey.
+	// If this is zero, it defaults to ExpiryDuration.
+	GenerateInterval time.Duration
+
+	// ExpiryDuration holds the minimum length of time that
+	// root keys will be valid for after they are returned from
+	// RootKey. The maximum length of time that they
+	// will be valid for is ExpiryDuration + GenerateInterval.
+	ExpiryDuration time.Duration
+}
+
+// NewStore returns a new RootKeyStore implementation that
+// stores and obtains root keys from the given collection.
+//
+// Root keys will be generated and stored following the
+// given store policy.
+//
+// It is expected that all Backing instances passed to a given Store's
+// NewStore method should refer to the same underlying database.
+func (s *RootKeys) NewStore(b Backing, policy Policy) bakery.RootKeyStore {
+	if policy.GenerateInterval == 0 {
+		policy.GenerateInterval = policy.ExpiryDuration
+	}
+	return &store{
+		keys:    s,
+		backing: b,
+		policy:  policy,
+	}
+}
+
+// get gets the root key for the given id, trying the cache first and
+// falling back to calling fallback if it's not found there.
+//
+// If the key does not exist or has expired, it returns
+// bakery.ErrNotFound.
+//
+// Called with s.mu locked.
+func (s *RootKeys) get(id []byte, b Backing) (RootKey, error) {
+	key, cached, err := s.get0(id, b)
+	if err != nil && err != bakery.ErrNotFound {
+		return RootKey{}, errgo.Mask(err)
+	}
+	if err == nil && s.clock.Now().After(key.Expires) {
+		key = RootKey{}
+		err = bakery.ErrNotFound
+	}
+	if !cached {
+		s.addCache(id, key)
+	}
+	return key, err
+}
+
+// get0 is the inner version of RootKeys.get. It returns an item and reports
+// whether it was found in the cache, but doesn't check whether the
+// item has expired or move the returned item to s.cache.
+func (s *RootKeys) get0(id []byte, b Backing) (key RootKey, inCache bool, err error) {
+	if k, ok := s.cache[string(id)]; ok {
+		if !k.IsValid() {
+			return RootKey{}, true, bakery.ErrNotFound
+		}
+		return k, true, nil
+	}
+	if k, ok := s.oldCache[string(id)]; ok {
+		if !k.IsValid() {
+			return RootKey{}, false, bakery.ErrNotFound
+		}
+		return k, false, nil
+	}
+	logger.Infof("cache miss for %q", id)
+	k, err := b.GetKey(id)
+	return k, false, err
+}
+
+// addCache adds the given key to the cache.
+// Called with s.mu locked.
+func (s *RootKeys) addCache(id []byte, k RootKey) {
+	if len(s.cache) >= s.maxCacheSize {
+		s.oldCache = s.cache
+		s.cache = make(map[string]RootKey)
+	}
+	s.cache[string(id)] = k
+}
+
+// setCurrent sets the current key for the given store policy.
+// Called with s.mu locked.
+func (s *RootKeys) setCurrent(policy Policy, key RootKey) {
+	if len(s.current) > maxPolicyCache {
+		// Sanity check to avoid possibly memory leak:
+		// if some client is using arbitrarily many store
+		// policies, we don't want s.keys.current to endlessly
+		// expand, so just kill the cache if it grows too big.
+		// This will result in worse performance but it shouldn't
+		// happen in practice and it's better than using endless
+		// space.
+		s.current = make(map[Policy]RootKey)
+	}
+	s.current[policy] = key
+}
+
+type store struct {
+	keys    *RootKeys
+	policy  Policy
+	backing Backing
+}
+
+// Get implements bakery.RootKeyStore.Get.
+func (s *store) Get(ctx context.Context, id []byte) ([]byte, error) {
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+
+	key, err := s.keys.get(id, s.backing)
+	if err != nil {
+		return nil, err
+	}
+	return key.RootKey, nil
+}
+
+// RootKey implements bakery.RootKeyStore.RootKey by
+// returning an existing key from the cache when compatible
+// with the current policy.
+func (s *store) RootKey(context.Context) ([]byte, []byte, error) {
+	if key := s.rootKeyFromCache(); key.IsValid() {
+		return key.RootKey, key.Id, nil
+	}
+	logger.Debugf("root key cache miss")
+	// Try to find a root key from the collection.
+	// It doesn't matter much if two concurrent mongo
+	// clients are doing this at the same time because
+	// we don't mind if there are more keys than necessary.
+	//
+	// Note that this query mirrors the logic found in
+	// store.rootKeyFromCache.
+	key, err := s.findBestRootKey()
+	if err != nil {
+		return nil, nil, errgo.Notef(err, "cannot query existing keys")
+	}
+	if !key.IsValid() {
+		// No keys found anywhere, so let's create one.
+		var err error
+		key, err = s.generateKey()
+		if err != nil {
+			return nil, nil, errgo.Notef(err, "cannot generate key")
+		}
+		logger.Infof("new root key id %q; created %v; expires %v", key.Id, key.Created, key.Expires)
+		if err := s.backing.InsertKey(key); err != nil {
+			return nil, nil, errgo.Notef(err, "cannot create root key")
+		}
+	}
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+	s.keys.addCache(key.Id, key)
+	s.keys.setCurrent(s.policy, key)
+	return key.RootKey, key.Id, nil
+}
+
+func (s *store) findBestRootKey() (RootKey, error) {
+	now := s.keys.clock.Now()
+	createdAfter := now.Add(-s.policy.GenerateInterval)
+	expiresAfter := now.Add(s.policy.ExpiryDuration)
+	expiresBefore := now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval)
+	return s.backing.FindLatestKey(createdAfter, expiresAfter, expiresBefore)
+}
+
+// rootKeyFromCache returns a root key from the cached keys.
+// If no keys are found that are valid for s.policy, it returns
+// the zero key.
+func (s *store) rootKeyFromCache() RootKey {
+	s.keys.mu.Lock()
+	defer s.keys.mu.Unlock()
+	if k, ok := s.keys.current[s.policy]; ok && k.IsValidWithPolicy(s.policy, s.keys.clock.Now()) {
+		return k
+	}
+
+	// Find the most recently created key that's consistent with the
+	// store policy.
+	var current RootKey
+	for _, k := range s.keys.cache {
+		if k.IsValidWithPolicy(s.policy, s.keys.clock.Now()) && k.Created.After(current.Created) {
+			current = k
+		}
+	}
+	if current.IsValid() {
+		s.keys.current[s.policy] = current
+		return current
+	}
+	return RootKey{}
+}
+
+func (s *store) generateKey() (RootKey, error) {
+	newKey, err := randomBytes(24)
+	if err != nil {
+		return RootKey{}, err
+	}
+	newId, err := randomBytes(16)
+	if err != nil {
+		return RootKey{}, err
+	}
+	now := s.keys.clock.Now()
+	return RootKey{
+		Created: now,
+		Expires: now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval),
+		// TODO return just newId when we know we can always
+		// use non-text macaroon ids.
+		Id:      []byte(fmt.Sprintf("%x", newId)),
+		RootKey: newKey,
+	}, nil
+}
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate %d random bytes: %v", n, err)
+	}
+	return b, nil
+}
+
+// afterEq reports whether t0 is after or equal to t1.
+func afterEq(t0, t1 time.Time) bool {
+	return !t0.Before(t1)
+}
+
+// beforeEq reports whether t1 is before or equal to t0.
+func beforeEq(t0, t1 time.Time) bool {
+	return !t0.After(t1)
+}
+
+type wallClock struct{}
+
+func (wallClock) Now() time.Time {
+	return time.Now()
+}

--- a/bakery/dbrootkeystore/rootkey_test.go
+++ b/bakery/dbrootkeystore/rootkey_test.go
@@ -1,10 +1,8 @@
-package postgresrootkeystore_test
+package dbrootkeystore_test
 
 import (
-	"database/sql"
 	"time"
 
-	"github.com/juju/postgrestest"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
@@ -13,63 +11,25 @@ import (
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
-	"gopkg.in/macaroon-bakery.v2/bakery/postgresrootkeystore"
 )
+
+type RootKeyStoreSuite struct {
+	testing.LoggingSuite
+}
 
 var _ = gc.Suite(&RootKeyStoreSuite{})
 
-const testTable = "testrootkeys"
+var epoch = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-type RootKeyStoreSuite struct {
-	testing.CleanupSuite
-	testing.LoggingSuite
-	db_   *postgrestest.DB
-	db    *sql.DB
-	store *postgresrootkeystore.RootKeys
-}
-
-func (s *RootKeyStoreSuite) SetUpSuite(c *gc.C) {
-	s.LoggingSuite.SetUpSuite(c)
-	s.CleanupSuite.SetUpSuite(c)
-}
-
-func (s *RootKeyStoreSuite) TearDownSuite(c *gc.C) {
-	s.CleanupSuite.TearDownSuite(c)
-	s.LoggingSuite.TearDownSuite(c)
-}
-
-func (s *RootKeyStoreSuite) SetUpTest(c *gc.C) {
-	s.LoggingSuite.SetUpTest(c)
-	s.CleanupSuite.SetUpTest(c)
-	db, err := postgrestest.New()
-	if err == postgrestest.ErrDisabled {
-		c.Skip("postgres testing is disabled")
-	}
-	c.Assert(err, gc.Equals, nil)
-	s.db_ = db
-	s.db = db.DB
-	s.store = postgresrootkeystore.NewRootKeys(s.db, testTable, 1)
-}
-
-func (s *RootKeyStoreSuite) TearDownTest(c *gc.C) {
-	err := s.store.Close()
-	c.Assert(err, gc.Equals, nil)
-	err = s.db_.Close()
-	c.Assert(err, gc.Equals, nil)
-	s.CleanupSuite.TearDownTest(c)
-}
-
-var epoch = time.Date(2200, time.January, 1, 0, 0, 0, 0, time.UTC)
-
-var IsValidWithPolicyTests = []struct {
+var isValidWithPolicyTests = []struct {
 	about  string
-	policy postgresrootkeystore.Policy
+	policy dbrootkeystore.Policy
 	now    time.Time
 	key    dbrootkeystore.RootKey
 	expect bool
 }{{
 	about: "success",
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   3 * time.Minute,
 	},
@@ -83,7 +43,7 @@ var IsValidWithPolicyTests = []struct {
 	expect: true,
 }, {
 	about: "empty root key",
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   3 * time.Minute,
 	},
@@ -92,7 +52,7 @@ var IsValidWithPolicyTests = []struct {
 	expect: false,
 }, {
 	about: "created too early",
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   3 * time.Minute,
 	},
@@ -106,7 +66,7 @@ var IsValidWithPolicyTests = []struct {
 	expect: false,
 }, {
 	about: "expires too early",
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   3 * time.Minute,
 	},
@@ -120,7 +80,7 @@ var IsValidWithPolicyTests = []struct {
 	expect: false,
 }, {
 	about: "expires too late",
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   3 * time.Minute,
 	},
@@ -135,30 +95,27 @@ var IsValidWithPolicyTests = []struct {
 }}
 
 func (s *RootKeyStoreSuite) TestIsValidWithPolicy(c *gc.C) {
-	for i, test := range IsValidWithPolicyTests {
+	for i, test := range isValidWithPolicyTests {
 		c.Logf("test %d: %v", i, test.about)
-		c.Assert(test.key.IsValidWithPolicy(dbrootkeystore.Policy(test.policy), test.now), gc.Equals, test.expect)
+		c.Assert(test.key.IsValidWithPolicy(test.policy, test.now), gc.Equals, test.expect)
 	}
 }
 
 func (s *RootKeyStoreSuite) TestRootKeyUsesKeysValidWithPolicy(c *gc.C) {
 	// We re-use the TestIsValidWithPolicy tests so that we
-	// know that the mongo logic uses the same behaviour.
-	var now time.Time
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
-	for i, test := range IsValidWithPolicyTests {
+	// know that the database-backed logic uses the same behaviour.
+	for i, test := range isValidWithPolicyTests {
 		c.Logf("test %d: %v", i, test.about)
 		if test.key.RootKey == nil {
 			// We don't store empty root keys in the database.
 			c.Logf("skipping test with empty root key")
 			continue
 		}
-		// Prime the table with the root key document.
-		s.primeRootKeys(c, []dbrootkeystore.RootKey{test.key})
-		store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(test.policy)
-		now = test.now
+		// Prime the collection with the root key document.
+		b := memBackingWithKeys([]dbrootkeystore.RootKey{test.key})
+		store := dbrootkeystore.NewRootKeys(10, stoppedClock(test.now)).NewStore(b, test.policy)
 		key, id, err := store.RootKey(context.Background())
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if test.expect {
 			c.Assert(string(id), gc.Equals, "id")
 			c.Assert(string(key), gc.Equals, "key")
@@ -173,14 +130,15 @@ func (s *RootKeyStoreSuite) TestRootKeyUsesKeysValidWithPolicy(c *gc.C) {
 
 func (s *RootKeyStoreSuite) TestRootKey(c *gc.C) {
 	now := epoch
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
+	clock := clockVal(&now)
+	b := make(memBacking)
 
-	store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(postgresrootkeystore.Policy{
+	store := dbrootkeystore.NewRootKeys(10, clock).NewStore(b, dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   5 * time.Minute,
 	})
 	key, id, err := store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key, gc.HasLen, 24)
 	c.Assert(id, gc.HasLen, 32)
 
@@ -188,24 +146,24 @@ func (s *RootKeyStoreSuite) TestRootKey(c *gc.C) {
 	// get the same one.
 	now = epoch.Add(time.Minute)
 	key1, id1, err := store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key1, gc.DeepEquals, key)
 	c.Assert(id1, gc.DeepEquals, id)
 
 	// A different store instance should get the same root key.
-	store1 := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(postgresrootkeystore.Policy{
+	store1 := dbrootkeystore.NewRootKeys(10, clock).NewStore(b, dbrootkeystore.Policy{
 		GenerateInterval: 2 * time.Minute,
 		ExpiryDuration:   5 * time.Minute,
 	})
 	key1, id1, err = store1.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key1, gc.DeepEquals, key)
 	c.Assert(id1, gc.DeepEquals, id)
 
 	// After the generation interval has passed, we should generate a new key.
 	now = epoch.Add(2*time.Minute + time.Second)
 	key1, id1, err = store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key, gc.HasLen, 24)
 	c.Assert(id, gc.HasLen, 32)
 	c.Assert(key1, gc.Not(gc.DeepEquals), key)
@@ -213,29 +171,30 @@ func (s *RootKeyStoreSuite) TestRootKey(c *gc.C) {
 
 	// The other store should pick it up too.
 	key2, id2, err := store1.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key2, gc.DeepEquals, key1)
 	c.Assert(id2, gc.DeepEquals, id1)
 }
 
 func (s *RootKeyStoreSuite) TestRootKeyDefaultGenerateInterval(c *gc.C) {
 	now := epoch
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
-	store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(postgresrootkeystore.Policy{
+	clock := clockVal(&now)
+	b := make(memBacking)
+	store := dbrootkeystore.NewRootKeys(10, clock).NewStore(b, dbrootkeystore.Policy{
 		ExpiryDuration: 5 * time.Minute,
 	})
 	key, id, err := store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	now = epoch.Add(5 * time.Minute)
 	key1, id1, err := store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(key1, jc.DeepEquals, key)
 	c.Assert(id1, jc.DeepEquals, id)
 
 	now = epoch.Add(5*time.Minute + time.Millisecond)
 	key1, id1, err = store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(key1), gc.Not(gc.Equals), string(key))
 	c.Assert(string(id1), gc.Not(gc.Equals), string(id))
 }
@@ -244,8 +203,8 @@ var preferredRootKeyTests = []struct {
 	about    string
 	now      time.Time
 	keys     []dbrootkeystore.RootKey
-	policy   postgresrootkeystore.Policy
-	expectId []byte
+	policy   dbrootkeystore.Policy
+	expectId string
 }{{
 	about: "latest creation time is preferred",
 	now:   epoch.Add(5 * time.Minute),
@@ -265,11 +224,11 @@ var preferredRootKeyTests = []struct {
 		Id:      []byte("id2"),
 		RootKey: []byte("key2"),
 	}},
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 5 * time.Minute,
 		ExpiryDuration:   7 * time.Minute,
 	},
-	expectId: []byte("id1"),
+	expectId: "id1",
 }, {
 	about: "ineligible keys are exluded",
 	now:   epoch.Add(5 * time.Minute),
@@ -289,70 +248,55 @@ var preferredRootKeyTests = []struct {
 		Id:      []byte("id2"),
 		RootKey: []byte("key2"),
 	}},
-	policy: postgresrootkeystore.Policy{
+	policy: dbrootkeystore.Policy{
 		GenerateInterval: 5 * time.Minute,
 		ExpiryDuration:   7 * time.Minute,
 	},
-	expectId: []byte("id1"),
+	expectId: "id1",
 }}
 
 func (s *RootKeyStoreSuite) TestPreferredRootKeyFromDatabase(c *gc.C) {
-	var now time.Time
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
 	for i, test := range preferredRootKeyTests {
 		c.Logf("%d: %v", i, test.about)
-		s.primeRootKeys(c, test.keys)
-		store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(test.policy)
-		now = test.now
+		b := memBackingWithKeys(test.keys)
+		store := dbrootkeystore.NewRootKeys(10, stoppedClock(test.now)).NewStore(b, test.policy)
 		_, id, err := store.RootKey(context.Background())
-		c.Assert(err, gc.IsNil)
-		c.Assert(id, gc.DeepEquals, test.expectId)
+		c.Assert(err, gc.Equals, nil)
+		c.Assert(string(id), gc.DeepEquals, test.expectId)
 	}
 }
 
 func (s *RootKeyStoreSuite) TestPreferredRootKeyFromCache(c *gc.C) {
-	var now time.Time
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
 	for i, test := range preferredRootKeyTests {
 		c.Logf("%d: %v", i, test.about)
-		s.primeRootKeys(c, test.keys)
-		store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(test.policy)
+		b := memBackingWithKeys(test.keys)
+		store := dbrootkeystore.NewRootKeys(10, stoppedClock(test.now)).NewStore(b, test.policy)
 		// Ensure that all the keys are in cache by getting all of them.
 		for _, key := range test.keys {
 			got, err := store.Get(context.Background(), key.Id)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(got, jc.DeepEquals, key.RootKey)
 		}
 		// Remove all the keys from the collection so that
 		// we know we must be acquiring them from the cache.
-		s.primeRootKeys(c, nil)
-
-		c.Logf("all keys removed")
+		for id := range b {
+			delete(b, id)
+		}
 
 		// Test that RootKey returns the expected key.
-		now = test.now
-		k, id, err := store.RootKey(context.Background())
-		c.Logf("rootKey %#v; id %#v; err %v", k, id, err)
-		c.Assert(err, gc.IsNil)
-		c.Assert(id, jc.DeepEquals, test.expectId)
+		_, id, err := store.RootKey(context.Background())
+		c.Assert(err, gc.Equals, nil)
+		c.Assert(string(id), jc.DeepEquals, test.expectId)
 	}
 }
 
 func (s *RootKeyStoreSuite) TestGet(c *gc.C) {
 	now := epoch
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
-	var fetched []string
-	s.PatchValue(postgresrootkeystore.NewBacking, func(keys *postgresrootkeystore.RootKeys) dbrootkeystore.Backing {
-		b := postgresrootkeystore.Backing(keys)
-		return &funcBacking{
-			Backing: b,
-			getKey: func(id []byte) (dbrootkeystore.RootKey, error) {
-				fetched = append(fetched, string(id))
-				return b.GetKey(id)
-			},
-		}
-	})
-	store := postgresrootkeystore.NewRootKeys(s.db, testTable, 5).NewStore(postgresrootkeystore.Policy{
+	clock := clockVal(&now)
+
+	mb := make(memBacking)
+	b := &funcBacking{Backing: mb}
+	store := dbrootkeystore.NewRootKeys(5, clock).NewStore(b, dbrootkeystore.Policy{
 		GenerateInterval: 1 * time.Minute,
 		ExpiryDuration:   30 * time.Minute,
 	})
@@ -364,14 +308,14 @@ func (s *RootKeyStoreSuite) TestGet(c *gc.C) {
 	keyIds := make(map[string]bool)
 	for i := 0; i < 20; i++ {
 		key, id, err := store.RootKey(context.Background())
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(keyIds[string(id)], gc.Equals, false)
 		keys = append(keys, idKey{string(id), key})
 		now = now.Add(time.Minute + time.Second)
 	}
 	for i, k := range keys {
 		key, err := store.Get(context.Background(), []byte(k.id))
-		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
+		c.Assert(err, gc.Equals, nil, gc.Commentf("key %d (%s)", i, k.id))
 		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
 	}
 	// Check that the keys are cached.
@@ -388,13 +332,18 @@ func (s *RootKeyStoreSuite) TestGet(c *gc.C) {
 	// The upshot of that is that all but the first 6 calls to Get
 	// should result in a database fetch.
 
+	var fetched []string
+	b.getKey = func(id []byte) (dbrootkeystore.RootKey, error) {
+		fetched = append(fetched, string(id))
+		return mb.GetKey(id)
+	}
 	c.Logf("testing cache")
-	fetched = nil
+
 	for i := len(keys) - 1; i >= 0; i-- {
 		k := keys[i]
 		key, err := store.Get(context.Background(), []byte(k.id))
-		c.Assert(err, gc.IsNil)
-		c.Assert(err, gc.IsNil, gc.Commentf("key %d (%s)", i, k.id))
+		c.Assert(err, gc.Equals, nil)
+		c.Assert(err, gc.Equals, nil, gc.Commentf("key %d (%s)", i, k.id))
 		c.Assert(key, gc.DeepEquals, k.key, gc.Commentf("key %d (%s)", i, k.id))
 	}
 	c.Assert(len(fetched), gc.Equals, len(keys)-6)
@@ -405,22 +354,20 @@ func (s *RootKeyStoreSuite) TestGet(c *gc.C) {
 
 func (s *RootKeyStoreSuite) TestGetCachesMisses(c *gc.C) {
 	var fetched []string
-	s.PatchValue(postgresrootkeystore.NewBacking, func(keys *postgresrootkeystore.RootKeys) dbrootkeystore.Backing {
-		b := postgresrootkeystore.Backing(keys)
-		return &funcBacking{
-			Backing: b,
-			getKey: func(id []byte) (dbrootkeystore.RootKey, error) {
-				fetched = append(fetched, string(id))
-				return b.GetKey(id)
-			},
-		}
-	})
-	store := postgresrootkeystore.NewRootKeys(s.db, testTable, 5).NewStore(postgresrootkeystore.Policy{
+	mb := make(memBacking)
+	b := &funcBacking{
+		Backing: mb,
+		getKey: func(id []byte) (dbrootkeystore.RootKey, error) {
+			fetched = append(fetched, string(id))
+			return mb.GetKey(id)
+		},
+	}
+	store := dbrootkeystore.NewRootKeys(5, nil).NewStore(b, dbrootkeystore.Policy{
 		GenerateInterval: 1 * time.Minute,
 		ExpiryDuration:   30 * time.Minute,
 	})
 	key, err := store.Get(context.Background(), []byte("foo"))
-	c.Assert(errgo.Cause(err), gc.Equals, bakery.ErrNotFound)
+	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 	c.Assert(key, gc.IsNil)
 	c.Assert(fetched, jc.DeepEquals, []string{"foo"})
 	fetched = nil
@@ -433,78 +380,78 @@ func (s *RootKeyStoreSuite) TestGetCachesMisses(c *gc.C) {
 
 func (s *RootKeyStoreSuite) TestGetExpiredItemFromCache(c *gc.C) {
 	now := epoch
-	s.PatchValue(postgresrootkeystore.Clock, clockVal(&now))
-	store := postgresrootkeystore.NewRootKeys(s.db, testTable, 10).NewStore(postgresrootkeystore.Policy{
+	clock := clockVal(&now)
+	b := &funcBacking{
+		Backing: make(memBacking),
+	}
+	store := dbrootkeystore.NewRootKeys(10, clock).NewStore(b, dbrootkeystore.Policy{
 		ExpiryDuration: 5 * time.Minute,
 	})
 	_, id, err := store.RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
-	s.PatchValue(postgresrootkeystore.NewBacking, func(keys *postgresrootkeystore.RootKeys) dbrootkeystore.Backing {
-		return &funcBacking{
-			Backing: postgresrootkeystore.Backing(keys),
-			getKey: func(id []byte) (dbrootkeystore.RootKey, error) {
-				c.Errorf("FindId unexpectedly called")
-				return dbrootkeystore.RootKey{}, nil
-			},
-		}
-	})
-
+	b.getKey = func(id []byte) (dbrootkeystore.RootKey, error) {
+		c.Errorf("GetKey unexpectedly called")
+		return dbrootkeystore.RootKey{}, errgo.New("unexpected call to GetKey")
+	}
 	now = epoch.Add(15 * time.Minute)
 
 	_, err = store.Get(context.Background(), id)
 	c.Assert(err, gc.Equals, bakery.ErrNotFound)
 }
 
-const sqlTimeFormat = "2006-01-02 15:04:05.9999-07"
-
-func (s *RootKeyStoreSuite) TestKeyExpiration(c *gc.C) {
-	keys := postgresrootkeystore.NewRootKeys(s.db, testTable, 5)
-
-	_, id1, err := keys.NewStore(postgresrootkeystore.Policy{
-		ExpiryDuration:   100 * time.Millisecond,
-		GenerateInterval: time.Nanosecond,
-	}).RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
-
-	_, id2, err := keys.NewStore(postgresrootkeystore.Policy{
-		ExpiryDuration: time.Hour,
-	}).RootKey(context.Background())
-	c.Assert(err, gc.IsNil)
-	c.Assert(string(id2), gc.Not(gc.Equals), string(id1))
-
-	// Sanity check that the keys are in the collection.
-	var n int
-	err = s.db.QueryRow(`SELECT count(id) FROM ` + testTable).Scan(&n)
-	c.Assert(err, gc.Equals, nil)
-	c.Assert(n, gc.Equals, 2)
-
-	// Sleep past the expiry time of the first key.
-	time.Sleep(150 * time.Millisecond)
-
-	// Use a store with a short generate interval to force
-	// another key to be generated, which should trigger
-	// the expiration check (the trigger is on INSERT).
-	_, _, err = keys.NewStore(postgresrootkeystore.Policy{
-		GenerateInterval: time.Nanosecond,
-		ExpiryDuration:   time.Hour,
-	}).RootKey(context.Background())
-	c.Assert(err, gc.Equals, nil)
-
-	_, err = postgresrootkeystore.Backing(s.store).GetKey(id1)
-	c.Assert(errgo.Cause(err), gc.Equals, bakery.ErrNotFound)
+func memBackingWithKeys(keys []dbrootkeystore.RootKey) memBacking {
+	b := make(memBacking)
+	for _, key := range keys {
+		err := b.InsertKey(key)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return b
 }
 
-// primeRootKeys deletes all rows from the root key table
-// and inserts the given keys.
-func (s *RootKeyStoreSuite) primeRootKeys(c *gc.C, keys []dbrootkeystore.RootKey) {
-	// Ignore any error from the delete - it's probably happening
-	// because the table does not exist yet.
-	s.db.Exec(`DELETE FROM ` + testTable)
-	for _, key := range keys {
-		err := postgresrootkeystore.Backing(s.store).InsertKey(key)
-		c.Assert(err, gc.IsNil)
+type funcBacking struct {
+	dbrootkeystore.Backing
+	getKey func(id []byte) (dbrootkeystore.RootKey, error)
+}
+
+func (b *funcBacking) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	if b.getKey == nil {
+		return b.Backing.GetKey(id)
 	}
+	return b.getKey(id)
+}
+
+type memBacking map[string]dbrootkeystore.RootKey
+
+func (b memBacking) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	key, ok := b[string(id)]
+	if !ok {
+		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
+	}
+	return key, nil
+}
+
+func (b memBacking) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	var best dbrootkeystore.RootKey
+	for _, k := range b {
+		if afterEq(k.Created, createdAfter) &&
+			afterEq(k.Expires, expiresAfter) &&
+			beforeEq(k.Expires, expiresBefore) &&
+			k.Created.After(best.Created) {
+			best = k
+		}
+	}
+	return best, nil
+}
+
+func (b memBacking) InsertKey(key dbrootkeystore.RootKey) error {
+	if _, ok := b[string(key.Id)]; ok {
+		return errgo.Newf("duplicate key")
+	}
+	b[string(key.Id)] = key
+	return nil
 }
 
 func clockVal(t *time.Time) dbrootkeystore.Clock {
@@ -519,14 +466,18 @@ func (f clockFunc) Now() time.Time {
 	return f()
 }
 
-type funcBacking struct {
-	dbrootkeystore.Backing
-	getKey func(id []byte) (dbrootkeystore.RootKey, error)
+// afterEq reports whether t0 is after or equal to t1.
+func afterEq(t0, t1 time.Time) bool {
+	return !t0.Before(t1)
 }
 
-func (b *funcBacking) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
-	if b.getKey == nil {
-		return b.Backing.GetKey(id)
-	}
-	return b.getKey(id)
+// beforeEq reports whether t1 is before or equal to t0.
+func beforeEq(t0, t1 time.Time) bool {
+	return !t0.After(t1)
+}
+
+func stoppedClock(t time.Time) dbrootkeystore.Clock {
+	return clockFunc(func() time.Time {
+		return t
+	})
 }

--- a/bakery/mgorootkeystore/export_test.go
+++ b/bakery/mgorootkeystore/export_test.go
@@ -1,12 +1,6 @@
 package mgorootkeystore
 
 var (
-	TimeNow             = &timeNow
+	Clock               = &clock
 	MgoCollectionFindId = &mgoCollectionFindId
 )
-
-type RootKey rootKey
-
-func IsValidWithPolicy(k RootKey, p Policy) bool {
-	return rootKey(k).isValidWithPolicy(p)
-}

--- a/bakery/mgorootkeystore/rootkey.go
+++ b/bakery/mgorootkeystore/rootkey.go
@@ -3,27 +3,31 @@
 package mgorootkeystore
 
 import (
-	"crypto/rand"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/juju/loggo"
-	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
 )
 
 // Functions defined as variables so they can be overidden
 // for testing.
 var (
-	timeNow = time.Now
-
+	clock               dbrootkeystore.Clock
 	mgoCollectionFindId = (*mgo.Collection).FindId
 )
+
+// TODO it would be nice if could make Policy
+// a type alias for dbrootkeystore.Policy,
+// but we want to be able to support versions
+// of Go from before type aliases were introduced.
+
+// Policy holds a store policy for root keys.
+type Policy dbrootkeystore.Policy
 
 var logger = loggo.GetLogger("bakery.mgorootkeystore")
 
@@ -37,43 +41,7 @@ const maxPolicyCache = 100
 
 // RootKeys represents a cache of macaroon root keys.
 type RootKeys struct {
-	maxCacheSize int
-
-	// TODO (rogpeppe) use RWMutex instead of Mutex here so that
-	// it's faster in the probably-common case that we
-	// have many contended readers.
-	mu       sync.Mutex
-	oldCache map[string]rootKey
-	cache    map[string]rootKey
-
-	// current holds the current root key for each store policy.
-	current map[Policy]rootKey
-}
-
-type rootKey struct {
-	Id      []byte `bson:"_id"`
-	Created time.Time
-	Expires time.Time
-	RootKey []byte
-}
-
-// isValid reports whether the root key contains a key. Note that we
-// always generate non-empty root keys, so we use this to find
-// whether the root key is empty or not.
-func (rk rootKey) isValid() bool {
-	return rk.RootKey != nil
-}
-
-// isValidWithPolicy reports whether the given root key
-// is currently valid to use with the given store policy.
-func (rk rootKey) isValidWithPolicy(p Policy) bool {
-	if !rk.isValid() {
-		return false
-	}
-	now := timeNow()
-	return afterEq(rk.Created, now.Add(-p.GenerateInterval)) &&
-		afterEq(rk.Expires, now.Add(p.ExpiryDuration)) &&
-		beforeEq(rk.Expires, now.Add(p.ExpiryDuration+p.GenerateInterval))
+	keys *dbrootkeystore.RootKeys
 }
 
 // NewRootKeys returns a root-keys cache that
@@ -84,24 +52,8 @@ func (rk rootKey) isValidWithPolicy(p Policy) bool {
 // policy.
 func NewRootKeys(maxCacheSize int) *RootKeys {
 	return &RootKeys{
-		maxCacheSize: maxCacheSize,
-		cache:        make(map[string]rootKey),
-		current:      make(map[Policy]rootKey),
+		keys: dbrootkeystore.NewRootKeys(maxCacheSize, clock),
 	}
-}
-
-// Policy holds a store policy for root keys.
-type Policy struct {
-	// GenerateInterval holds the maximum length of time
-	// for which a root key will be returned from RootKey.
-	// If this is zero, it defaults to ExpiryDuration.
-	GenerateInterval time.Duration
-
-	// ExpiryDuration holds the minimum length of time that
-	// root keys will be valid for after they are returned from
-	// RootKey. The maximum length of time that they
-	// will be valid for is ExpiryDuration + GenerateInterval.
-	ExpiryDuration time.Duration
 }
 
 // NewStore returns a new RootKeyStore implementation that
@@ -113,14 +65,7 @@ type Policy struct {
 // It is expected that all collections passed to a given Store's
 // NewStore method should refer to the same underlying collection.
 func (s *RootKeys) NewStore(c *mgo.Collection, policy Policy) bakery.RootKeyStore {
-	if policy.GenerateInterval == 0 {
-		policy.GenerateInterval = policy.ExpiryDuration
-	}
-	return &store{
-		keys:   s,
-		coll:   c,
-		policy: policy,
-	}
+	return s.keys.NewStore(backing{c}, dbrootkeystore.Policy(policy))
 }
 
 var indexes = []mgo.Index{{
@@ -142,101 +87,18 @@ func (s *RootKeys) EnsureIndex(c *mgo.Collection) error {
 	return nil
 }
 
-// get gets the root key for the given id, trying the cache first and
-// falling back to calling fallback if it's not found there.
-//
-// If the key does not exist or has expired, it returns
-// bakery.ErrNotFound.
-//
-// Called with s.mu locked.
-func (s *RootKeys) get(id []byte, fallback func(id []byte) (rootKey, error)) (rootKey, error) {
-	key, cached, err := s.get0(id, fallback)
-	if err != nil && err != bakery.ErrNotFound {
-		return rootKey{}, errgo.Mask(err)
-	}
-	if err == nil && timeNow().After(key.Expires) {
-		key = rootKey{}
-		err = bakery.ErrNotFound
-	}
-	if !cached {
-		s.addCache(id, key)
-	}
-	return key, err
+type backing struct {
+	coll *mgo.Collection
 }
 
-// get0 is the inner version of RootKeys.get. It returns an item and reports
-// whether it was found in the cache, but doesn't check whether the
-// item has expired or move the returned item to s.cache.
-func (s *RootKeys) get0(id []byte, fallback func(id []byte) (rootKey, error)) (key rootKey, inCache bool, err error) {
-	if k, ok := s.cache[string(id)]; ok {
-		if !k.isValid() {
-			return rootKey{}, true, bakery.ErrNotFound
-		}
-		return k, true, nil
-	}
-	if k, ok := s.oldCache[string(id)]; ok {
-		if !k.isValid() {
-			return rootKey{}, false, bakery.ErrNotFound
-		}
-		return k, false, nil
-	}
-	logger.Infof("cache miss for %q", id)
-	k, err := fallback(id)
-	return k, false, err
-}
-
-// addCache adds the given key to the cache.
-// Called with s.mu locked.
-func (s *RootKeys) addCache(id []byte, k rootKey) {
-	if len(s.cache) >= s.maxCacheSize {
-		s.oldCache = s.cache
-		s.cache = make(map[string]rootKey)
-	}
-	s.cache[string(id)] = k
-}
-
-// setCurrent sets the current key for the given store policy.
-// Called with s.mu locked.
-func (s *RootKeys) setCurrent(policy Policy, key rootKey) {
-	if len(s.current) > maxPolicyCache {
-		// Sanity check to avoid possibly memory leak:
-		// if some client is using arbitrarily many store
-		// policies, we don't want s.keys.current to endlessly
-		// expand, so just kill the cache if it grows too big.
-		// This will result in worse performance but it shouldn't
-		// happen in practice and it's better than using endless
-		// space.
-		s.current = make(map[Policy]rootKey)
-	}
-	s.current[policy] = key
-}
-
-type store struct {
-	keys   *RootKeys
-	policy Policy
-	coll   *mgo.Collection
-}
-
-// Get implements bakery.RootKeyStore.Get.
-func (s *store) Get(ctx context.Context, id []byte) ([]byte, error) {
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-
-	key, err := s.keys.get(id, s.getFromMongo)
-	if err != nil {
-		return nil, err
-	}
-	return key.RootKey, nil
-}
-
-func (s *store) getFromMongo(id []byte) (rootKey, error) {
-	var key rootKey
-	err := mgoCollectionFindId(s.coll, id).One(&key)
+func (b backing) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	var key dbrootkeystore.RootKey
+	err := mgoCollectionFindId(b.coll, id).One(&key)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return s.getLegacyFromMongo(string(id))
+			return b.getLegacyFromMongo(string(id))
 		}
-		return rootKey{}, errgo.Notef(err, "cannot get key from database")
+		return dbrootkeystore.RootKey{}, errgo.Notef(err, "cannot get key from database")
 	}
 	// TODO migrate the key from the old format to the new format.
 	return key, nil
@@ -245,125 +107,37 @@ func (s *store) getFromMongo(id []byte) (rootKey, error) {
 // getLegacyFromMongo gets a value from the old version of the
 // root key document which used a string key rather than a []byte
 // key.
-func (s *store) getLegacyFromMongo(id string) (rootKey, error) {
-	var key rootKey
-	err := mgoCollectionFindId(s.coll, id).One(&key)
+func (b backing) getLegacyFromMongo(id string) (dbrootkeystore.RootKey, error) {
+	var key dbrootkeystore.RootKey
+	err := mgoCollectionFindId(b.coll, id).One(&key)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return rootKey{}, bakery.ErrNotFound
+			return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 		}
-		return rootKey{}, errgo.Notef(err, "cannot get key from database")
+		return dbrootkeystore.RootKey{}, errgo.Notef(err, "cannot get key from database")
 	}
 	return key, nil
 }
 
-// RootKey implements bakery.RootKeyStore.RootKey by
-// returning an existing key from the cache when compatible
-// with the current policy.
-func (s *store) RootKey(context.Context) ([]byte, []byte, error) {
-	if key := s.rootKeyFromCache(); key.isValid() {
-		return key.RootKey, key.Id, nil
-	}
-	logger.Debugf("root key cache miss")
-	// Try to find a root key from the collection.
-	// It doesn't matter much if two concurrent mongo
-	// clients are doing this at the same time because
-	// we don't mind if there are more keys than necessary.
-	//
-	// Note that this query mirrors the logic found in
-	// store.rootKeyFromCache.
-	now := timeNow()
-	var key rootKey
-	err := s.coll.Find(bson.D{{
-		"created", bson.D{{"$gte", now.Add(-s.policy.GenerateInterval)}},
+func (b backing) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	var key dbrootkeystore.RootKey
+	err := b.coll.Find(bson.D{{
+		"created", bson.D{{"$gte", createdAfter}},
 	}, {
 		"expires", bson.D{
-			{"$gte", now.Add(s.policy.ExpiryDuration)},
-			{"$lte", now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval)},
+			{"$gte", expiresAfter},
+			{"$lte", expiresBefore},
 		},
 	}}).Sort("-created").One(&key)
 	if err != nil && err != mgo.ErrNotFound {
-		return nil, nil, errgo.Notef(err, "cannot query existing keys")
+		return dbrootkeystore.RootKey{}, errgo.Notef(err, "cannot query existing keys")
 	}
-	if !key.isValid() {
-		// No keys found anywhere, so let's create one.
-		var err error
-		key, err = s.generateKey()
-		if err != nil {
-			return nil, nil, errgo.Notef(err, "cannot generate key")
-		}
-		logger.Infof("new root key id %q; created %v; expires %v", key.Id, key.Created, key.Expires)
-		if err := s.coll.Insert(key); err != nil {
-			return nil, nil, errgo.Notef(err, "cannot create root key")
-		}
-	}
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-	s.keys.addCache(key.Id, key)
-	s.keys.setCurrent(s.policy, key)
-	return key.RootKey, key.Id, nil
+	return key, nil
 }
 
-// rootKeyFromCache returns a root key from the cached keys.
-// If no keys are found that are valid for s.policy, it returns
-// the zero key.
-func (s *store) rootKeyFromCache() rootKey {
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-	if k, ok := s.keys.current[s.policy]; ok && k.isValidWithPolicy(s.policy) {
-		return k
+func (b backing) InsertKey(key dbrootkeystore.RootKey) error {
+	if err := b.coll.Insert(key); err != nil {
+		return errgo.Notef(err, "mongo insert failed")
 	}
-
-	// Find the most recently created key that's consistent with the
-	// store policy.
-	var current rootKey
-	for _, k := range s.keys.cache {
-		if k.isValidWithPolicy(s.policy) && k.Created.After(current.Created) {
-			current = k
-		}
-	}
-	if current.isValid() {
-		s.keys.current[s.policy] = current
-		return current
-	}
-	return rootKey{}
-}
-
-func (s *store) generateKey() (rootKey, error) {
-	newKey, err := randomBytes(24)
-	if err != nil {
-		return rootKey{}, err
-	}
-	newId, err := randomBytes(16)
-	if err != nil {
-		return rootKey{}, err
-	}
-	now := timeNow()
-	return rootKey{
-		Created: now,
-		Expires: now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval),
-		// TODO return just newId when we know we can always
-		// use non-text macaroon ids.
-		Id:      []byte(fmt.Sprintf("%x", newId)),
-		RootKey: newKey,
-	}, nil
-}
-
-func randomBytes(n int) ([]byte, error) {
-	b := make([]byte, n)
-	_, err := rand.Read(b)
-	if err != nil {
-		return nil, fmt.Errorf("cannot generate %d random bytes: %v", n, err)
-	}
-	return b, nil
-}
-
-// afterEq reports whether t0 is after or equal to t1.
-func afterEq(t0, t1 time.Time) bool {
-	return !t0.Before(t1)
-}
-
-// beforeEq reports whether t1 is before or equal to t0.
-func beforeEq(t0, t1 time.Time) bool {
-	return !t0.After(t1)
+	return nil
 }

--- a/bakery/postgresrootkeystore/export_test.go
+++ b/bakery/postgresrootkeystore/export_test.go
@@ -1,0 +1,12 @@
+package postgresrootkeystore
+
+import "gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+
+var (
+	Clock      = &clock
+	NewBacking = &newBacking
+)
+
+func Backing(keys *RootKeys) dbrootkeystore.Backing {
+	return backing{keys}
+}

--- a/bakery/postgresrootkeystore/rootkey.go
+++ b/bakery/postgresrootkeystore/rootkey.go
@@ -3,26 +3,32 @@
 package postgresrootkeystore
 
 import (
-	"crypto/rand"
 	"database/sql"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/juju/loggo"
-	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/mgo.v2"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
 )
 
-// Functions defined as variables so they can be overidden
-// for testing.
+// Variables defined so they can be overidden for testing.
 var (
-	timeNow        = time.Now
-	rootKeysFindId = (*RootKeys).findId
+	clock      dbrootkeystore.Clock
+	newBacking = func(s *RootKeys) dbrootkeystore.Backing {
+		return backing{s}
+	}
 )
+
+// TODO it would be nice if could make Policy
+// a type alias for dbrootkeystore.Policy,
+// but we want to be able to support versions
+// of Go from before type aliases were introduced.
+
+// Policy holds a store policy for root keys.
+type Policy dbrootkeystore.Policy
 
 var logger = loggo.GetLogger("bakery.postgresrootkeystore")
 
@@ -36,6 +42,8 @@ const maxPolicyCache = 100
 
 // RootKeys represents a cache of macaroon root keys.
 type RootKeys struct {
+	keys *dbrootkeystore.RootKeys
+
 	db    *sql.DB
 	table string
 	stmts [numStmts]*sql.Stmt
@@ -43,44 +51,6 @@ type RootKeys struct {
 	// initDBOnce guards initDBErr.
 	initDBOnce sync.Once
 	initDBErr  error
-
-	maxCacheSize int
-
-	// TODO (rogpeppe) use RWMutex instead of Mutex here so that
-	// it's faster in the probably-common case that we
-	// have many contended readers.
-	mu       sync.Mutex
-	oldCache map[string]rootKey
-	cache    map[string]rootKey
-
-	// current holds the current root key for each store policy.
-	current map[Policy]rootKey
-}
-
-type rootKey struct {
-	id      []byte
-	created time.Time
-	expires time.Time
-	rootKey []byte
-}
-
-// isValid reports whether the root key contains a key. Note that we
-// always generate non-empty root keys, so we use this to find
-// whether the root key is empty or not.
-func (rk rootKey) isValid() bool {
-	return rk.rootKey != nil
-}
-
-// isValidWithPolicy reports whether the given root key
-// is currently valid to use with the given store policy.
-func (rk rootKey) isValidWithPolicy(p Policy) bool {
-	if !rk.isValid() {
-		return false
-	}
-	now := timeNow()
-	return afterEq(rk.created, now.Add(-p.GenerateInterval)) &&
-		afterEq(rk.expires, now.Add(p.ExpiryDuration)) &&
-		beforeEq(rk.expires, now.Add(p.ExpiryDuration+p.GenerateInterval))
 }
 
 // NewRootKeys returns a root-keys cache that
@@ -99,11 +69,9 @@ func (rk rootKey) isValidWithPolicy(p Policy) bool {
 // lifetimes.
 func NewRootKeys(db *sql.DB, table string, maxCacheSize int) *RootKeys {
 	return &RootKeys{
-		maxCacheSize: maxCacheSize,
-		cache:        make(map[string]rootKey),
-		current:      make(map[Policy]rootKey),
-		db:           db,
-		table:        table,
+		keys:  dbrootkeystore.NewRootKeys(maxCacheSize, clock),
+		db:    db,
+		table: table,
 	}
 }
 
@@ -121,20 +89,6 @@ func (s *RootKeys) Close() error {
 	return errgo.Mask(retErr)
 }
 
-// Policy holds a store policy for root keys.
-type Policy struct {
-	// GenerateInterval holds the maximum length of time
-	// for which a root key will be returned from RootKey.
-	// If this is zero, it defaults to ExpiryDuration.
-	GenerateInterval time.Duration
-
-	// ExpiryDuration holds the minimum length of time that
-	// root keys will be valid for after they are returned from
-	// RootKey. The maximum length of time that they
-	// will be valid for is ExpiryDuration + GenerateInterval.
-	ExpiryDuration time.Duration
-}
-
 // NewStore returns a new RootKeyStore implementation that
 // stores and obtains root keys from the given collection.
 //
@@ -144,204 +98,27 @@ type Policy struct {
 // It is expected that all collections passed to a given Store's
 // NewStore method should refer to the same underlying collection.
 func (s *RootKeys) NewStore(policy Policy) bakery.RootKeyStore {
-	if policy.GenerateInterval == 0 {
-		policy.GenerateInterval = policy.ExpiryDuration
-	}
-	return &store{
-		keys:   s,
-		policy: policy,
-	}
+	b := newBacking(s)
+	return s.keys.NewStore(b, dbrootkeystore.Policy(policy))
 }
 
-// get gets the root key for the given id, trying the cache first and
-// falling back to calling fallback if it's not found there.
-//
-// If the key does not exist or has expired, it returns
-// bakery.ErrNotFound.
-//
-// Called with s.mu locked.
-func (s *RootKeys) get(id []byte) (rootKey, error) {
-	key, cached, err := s.get0(id)
-	if err != nil && err != bakery.ErrNotFound {
-		return rootKey{}, errgo.Mask(err)
-	}
-	if err == nil && timeNow().After(key.expires) {
-		key = rootKey{}
-		err = bakery.ErrNotFound
-	}
-	if !cached {
-		s.addCache(id, key)
-	}
-	return key, err
+// backing implements dbrootkeystore.Backing by using Postgres as
+// a backing store.
+type backing struct {
+	keys *RootKeys
 }
 
-// get0 is the inner version of RootKeys.get. It returns an item and reports
-// whether it was found in the cache, but doesn't check whether the
-// item has expired or move the returned item to s.cache.
-func (s *RootKeys) get0(id []byte) (key rootKey, inCache bool, err error) {
-	if k, ok := s.cache[string(id)]; ok {
-		if !k.isValid() {
-			return rootKey{}, true, bakery.ErrNotFound
-		}
-		return k, true, nil
-	}
-	if k, ok := s.oldCache[string(id)]; ok {
-		if !k.isValid() {
-			return rootKey{}, false, bakery.ErrNotFound
-		}
-		return k, false, nil
-	}
-	logger.Infof("cache miss for %q", id)
-	// Try to find the root key in the database. Note that we
-	// indirect through a variable rather than calling
-	// RootKeys.findId directly so that tests can check whether
-	// we're using it rather than using the cache.
-	k, err := rootKeysFindId(s, id)
-	return k, false, err
+// GetKey implements dbrootkeystore.Backing.GetKey.
+func (b backing) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	return b.keys.getKey(id)
 }
 
-// addCache adds the given key to the cache.
-// Called with s.mu locked.
-func (s *RootKeys) addCache(id []byte, k rootKey) {
-	if len(s.cache) >= s.maxCacheSize {
-		s.oldCache = s.cache
-		s.cache = make(map[string]rootKey)
-	}
-	s.cache[string(id)] = k
+// InsertKey implements dbrootkeystore.Backing.InsertKey.
+func (b backing) InsertKey(key dbrootkeystore.RootKey) error {
+	return b.keys.insertKey(key)
 }
 
-// setCurrent sets the current key for the given store policy.
-// Called with s.mu locked.
-func (s *RootKeys) setCurrent(policy Policy, key rootKey) {
-	if len(s.current) > maxPolicyCache {
-		// Sanity check to avoid possibly memory leak:
-		// if some client is using arbitrarily many store
-		// policies, we don't want s.keys.current to endlessly
-		// expand, so just kill the cache if it grows too big.
-		// This will result in worse performance but it shouldn't
-		// happen in practice and it's better than using endless
-		// space.
-		s.current = make(map[Policy]rootKey)
-	}
-	s.current[policy] = key
-}
-
-type store struct {
-	keys   *RootKeys
-	policy Policy
-	coll   *mgo.Collection
-}
-
-// Get implements bakery.RootKeyStore.Get.
-func (s *store) Get(ctx context.Context, id []byte) ([]byte, error) {
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-
-	key, err := s.keys.get(id)
-	if err != nil {
-		return nil, err
-	}
-	return key.rootKey, nil
-}
-
-// RootKey implements bakery.RootKeyStore.RootKey by
-// returning an existing key from the cache when compatible
-// with the current policy.
-func (s *store) RootKey(context.Context) ([]byte, []byte, error) {
-	if key := s.rootKeyFromCache(); key.isValid() {
-		return key.rootKey, key.id, nil
-	}
-	logger.Debugf("root key cache miss")
-	// Try to find a root key from the collection.
-	// It doesn't matter much if two concurrent mongo
-	// clients are doing this at the same time because
-	// we don't mind if there are more keys than necessary.
-	//
-	// Note that this query mirrors the logic found in
-	// store.rootKeyFromCache.
-	key, err := s.keys.findBestRootKey(s.policy)
-	if err != nil {
-		return nil, nil, errgo.Notef(err, "cannot query existing keys")
-	}
-	if !key.isValid() {
-		// No keys found anywhere, so let's create one.
-		var err error
-		key, err = s.generateKey()
-		if err != nil {
-			return nil, nil, errgo.Notef(err, "cannot generate key")
-		}
-		logger.Infof("new root key id %q; created %v; expires %v", key.id, key.created, key.expires)
-		if err := s.keys.insertKey(key); err != nil {
-			return nil, nil, errgo.Notef(err, "cannot create root key")
-		}
-	}
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-	s.keys.addCache(key.id, key)
-	s.keys.setCurrent(s.policy, key)
-	return key.rootKey, key.id, nil
-}
-
-// rootKeyFromCache returns a root key from the cached keys.
-// If no keys are found that are valid for s.policy, it returns
-// the zero key.
-func (s *store) rootKeyFromCache() rootKey {
-	s.keys.mu.Lock()
-	defer s.keys.mu.Unlock()
-	if k, ok := s.keys.current[s.policy]; ok && k.isValidWithPolicy(s.policy) {
-		return k
-	}
-
-	// Find the most recently created key that's consistent with the
-	// store policy.
-	var current rootKey
-	for _, k := range s.keys.cache {
-		if k.isValidWithPolicy(s.policy) && k.created.After(current.created) {
-			current = k
-		}
-	}
-	if current.isValid() {
-		s.keys.current[s.policy] = current
-		return current
-	}
-	return rootKey{}
-}
-
-func (s *store) generateKey() (rootKey, error) {
-	newKey, err := randomBytes(24)
-	if err != nil {
-		return rootKey{}, err
-	}
-	newId, err := randomBytes(16)
-	if err != nil {
-		return rootKey{}, err
-	}
-	now := timeNow()
-	return rootKey{
-		created: now,
-		expires: now.Add(s.policy.ExpiryDuration + s.policy.GenerateInterval),
-		// TODO return just newId when we know we can always
-		// use non-text macaroon ids.
-		id:      []byte(fmt.Sprintf("%x", newId)),
-		rootKey: newKey,
-	}, nil
-}
-
-func randomBytes(n int) ([]byte, error) {
-	b := make([]byte, n)
-	_, err := rand.Read(b)
-	if err != nil {
-		return nil, fmt.Errorf("cannot generate %d random bytes: %v", n, err)
-	}
-	return b, nil
-}
-
-// afterEq reports whether t0 is after or equal to t1.
-func afterEq(t0, t1 time.Time) bool {
-	return !t0.Before(t1)
-}
-
-// beforeEq reports whether t1 is before or equal to t0.
-func beforeEq(t0, t1 time.Time) bool {
-	return !t0.After(t1)
+// FindLatestKey implements dbrootkeystore.Backing.FindLatestKey.
+func (b backing) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	return b.keys.findLatestKey(createdAfter, expiresAfter, expiresBefore)
 }


### PR DESCRIPTION
We factor out the significant functionality from mgorootkeystore and
postgresrootkeystore into a shared package, in preparation
for adding support for more mgo forks without breaking
backward compatibility.

The original test suites are left intact to demonstrate lack of regression.
