### PR TITLE
Bring bakery.v2 to depend on the same version of mgo that Juju depends on

### DIFF
--- a/httpbakery/keyring_test.go
+++ b/httpbakery/keyring_test.go
@@ -140,7 +140,7 @@ func (s *KeyringSuite) TestThirdPartyInfoForLocationWrongURL(c *gc.C) {
 	_, err := httpbakery.ThirdPartyInfoForLocation(testContext, client, "http://localhost:0")
 	c.Logf("%v", errgo.Details(err))
 	c.Assert(err, gc.ErrorMatches,
-		`(Get|GET) http://localhost:0/discharge/info: dial tcp 127.0.0.1:0: .*connection refused`)
+		`(Get|GET) http://localhost:0/discharge/info: dial tcp (127.0.0.1|\[::1\]):0: .*connection refused`)
 }
 
 func (s *KeyringSuite) TestThirdPartyInfoForLocationReturnsInvalidJSON(c *gc.C) {


### PR DESCRIPTION
This runs the test suite cleanly with PGTESTDISABLE=1 go test ./...

I disabled the postgresql tests because there wasn't any instructions on how it wanted postgresql to be set up. And while I could install postgresql, it then complained about the user, and when I created a user, it then complained that password authentication didn't work.
However, the changes here shouldn't touch postgresql so I don't think it affects the test suite.
