### PR TITLE
use configurable logging

### DIFF
--- a/bakery/bakery.go
+++ b/bakery/bakery.go
@@ -20,6 +20,11 @@ type Bakery struct {
 // The zero value is OK to use, but won't allow any authentication
 // or third party caveats to be added.
 type BakeryParams struct {
+	// Logger is used to send log messages. If it is nil,
+	// DefaultLogger("bakery") will be used.
+	// github.com/juju/loggo will be used for logging.
+	Logger Logger
+
 	// Checker holds the checker used to check first party caveats.
 	// If this is nil, New will use checkers.New(nil).
 	Checker FirstPartyCaveatChecker

--- a/bakery/checker.go
+++ b/bakery/checker.go
@@ -46,6 +46,10 @@ type CheckerParams struct {
 
 	// MacaroonVerifier is used to verify macaroons.
 	MacaroonVerifier MacaroonVerifier
+
+	// Logger is used to log checker operations. If it is nil,
+	// DefaultLogger("bakery") will be used.
+	Logger Logger
 }
 
 // OpsAuthorizer is used to check whether an operation authorizes some other
@@ -124,6 +128,9 @@ func NewChecker(p CheckerParams) *Checker {
 	if p.Checker == nil {
 		p.Checker = checkers.New(nil)
 	}
+	if p.Logger == nil {
+		p.Logger = DefaultLogger("bakery")
+	}
 	return &Checker{
 		FirstPartyCaveatChecker: p.Checker,
 		p: p,
@@ -174,7 +181,7 @@ func (a *AuthChecker) initOnceFunc(ctx context.Context) error {
 			a.initErrors = append(a.initErrors, errgo.Mask(err))
 			continue
 		}
-		logger.Debugf("macaroon %d has valid sig; ops %q, conditions %q", i, ops, conditions)
+		a.p.Logger.Debugf(ctx, "macaroon %d has valid sig; ops %q, conditions %q", i, ops, conditions)
 		// It's a valid macaroon (in principle - we haven't checked first party caveats).
 		a.conditions[i] = conditions
 		for _, op := range ops {
@@ -322,7 +329,7 @@ func (a *AuthChecker) Allow(ctx context.Context, ops ...Op) (*AuthInfo, error) {
 		// No more ops need to be authenticated and no caveats to be discharged.
 		return actx.newAuthInfo(), nil
 	}
-	logger.Debugf("operations still needed after auth check: %#v", actx.need)
+	a.p.Logger.Debugf(ctx, "operations still needed after auth check: %#v", actx.need)
 	if len(caveats) == 0 || len(actx.need) > 0 {
 		allErrors := make([]error, 0, len(a.initErrors)+len(actx.errors))
 		allErrors = append(allErrors, a.initErrors...)
@@ -330,7 +337,7 @@ func (a *AuthChecker) Allow(ctx context.Context, ops ...Op) (*AuthInfo, error) {
 		var err error
 		if len(allErrors) > 0 {
 			// TODO return all errors?
-			logger.Infof("all auth errors: %q", allErrors)
+			a.p.Logger.Infof(ctx, "all auth errors: %q", allErrors)
 			err = allErrors[0]
 		}
 		return nil, errgo.WithCausef(err, ErrPermissionDenied, "")

--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -663,7 +663,6 @@ func (c *client) requestMacaroons(svc *service) []macaroon.Slice {
 	sort.Strings(names)
 	ms := make([]macaroon.Slice, len(names))
 	for i, name := range names {
-		logger.Infof("macaroon %d: %v", i, name)
 		ms[i] = mmap[name]
 	}
 	return ms

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
@@ -17,8 +16,6 @@ import (
 // testContext holds the testing background context - its associated time when checking
 // time-before caveats will always be the value of epoch.
 var testContext = checkers.ContextWithClock(context.Background(), stoppedClock{epoch})
-
-var logger = loggo.GetLogger("bakery.bakery_test")
 
 var basicOp = bakery.Op{"basic", "basic"}
 

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -6,14 +6,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 )
-
-var logger = loggo.GetLogger("bakery")
 
 // LocalThirdPartyCaveat returns a third-party caveat that, when added
 // to a macaroon with AddCaveat, results in a caveat
@@ -121,7 +118,6 @@ func Discharge(ctx context.Context, p DischargeParams) (*Macaroon, error) {
 		return nil, errgo.Notef(err, "discharger cannot decode caveat id")
 	}
 	cavInfo.Id = p.Id
-	logger.Infof("decoded discharge caveat %x as version %v", p.Caveat, cavInfo.Version)
 	// Note that we don't check the error - we allow the
 	// third party checker to see even caveats that we can't
 	// understand.

--- a/bakery/identchecker/checker_test.go
+++ b/bakery/identchecker/checker_test.go
@@ -775,7 +775,6 @@ func (c *client) requestMacaroons(svc *service) []macaroon.Slice {
 	sort.Strings(names)
 	ms := make([]macaroon.Slice, len(names))
 	for i, name := range names {
-		logger.Infof("macaroon %d: %v", i, name)
 		ms[i] = mmap[name]
 	}
 	return ms

--- a/bakery/identchecker/common_test.go
+++ b/bakery/identchecker/common_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	"gopkg.in/macaroon.v2"
 
@@ -15,8 +14,6 @@ import (
 // testContext holds the testing background context - its associated time when checking
 // time-before caveats will always be the value of epoch.
 var testContext = checkers.ContextWithClock(context.Background(), stoppedClock{epoch})
-
-var logger = loggo.GetLogger("bakery.bakery_test")
 
 var (
 	epoch = time.Date(1900, 11, 17, 19, 00, 13, 0, time.UTC)

--- a/bakery/logger.go
+++ b/bakery/logger.go
@@ -1,0 +1,34 @@
+package bakery
+
+import (
+	"github.com/juju/loggo"
+	"golang.org/x/net/context"
+)
+
+// Logger is used by the bakery to log informational messages
+// about bakery operations.
+type Logger interface {
+	Infof(ctx context.Context, f string, args ...interface{})
+	Debugf(ctx context.Context, f string, args ...interface{})
+}
+
+// DefaultLogger returns a Logger instance that uses
+// github.com/juju/loggo to log messages using the
+// given logger name.
+func DefaultLogger(name string) Logger {
+	return loggoLogger{loggo.GetLogger(name)}
+}
+
+type loggoLogger struct {
+	logger loggo.Logger
+}
+
+// Debugf implements Logger.Debugf.
+func (l loggoLogger) Debugf(_ context.Context, f string, args ...interface{}) {
+	l.logger.Debugf(f, args...)
+}
+
+// Debugf implements Logger.Infof.
+func (l loggoLogger) Infof(_ context.Context, f string, args ...interface{}) {
+	l.logger.Infof(f, args...)
+}

--- a/bakery/mgorootkeystore/rootkey.go
+++ b/bakery/mgorootkeystore/rootkey.go
@@ -5,7 +5,6 @@ package mgorootkeystore
 import (
 	"time"
 
-	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -28,8 +27,6 @@ var (
 
 // Policy holds a store policy for root keys.
 type Policy dbrootkeystore.Policy
-
-var logger = loggo.GetLogger("bakery.mgorootkeystore")
 
 // maxPolicyCache holds the maximum number of store policies that can
 // hold cached keys in a given RootKeys instance.

--- a/bakery/postgresrootkeystore/rootkey.go
+++ b/bakery/postgresrootkeystore/rootkey.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -29,8 +28,6 @@ var (
 
 // Policy holds a store policy for root keys.
 type Policy dbrootkeystore.Policy
-
-var logger = loggo.GetLogger("bakery.postgresrootkeystore")
 
 // maxPolicyCache holds the maximum number of store policies that can
 // hold cached keys in a given RootKeys instance.

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"sync"
 
-	"github.com/juju/loggo"
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
@@ -18,8 +17,6 @@ import (
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 )
-
-var logger = loggo.GetLogger("bakerytest")
 
 // Discharger represents a third party caveat discharger server.
 type Discharger struct {

--- a/httpbakery/agent/agent.go
+++ b/httpbakery/agent/agent.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
@@ -19,8 +18,6 @@ import (
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 )
-
-var logger = loggo.GetLogger("httpbakery.agent")
 
 // AuthInfo holds the agent information required
 // to set up agent authentication information.

--- a/httpbakery/form/form.go
+++ b/httpbakery/form/form.go
@@ -4,7 +4,6 @@ package form
 import (
 	"net/url"
 
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	"golang.org/x/net/publicsuffix"
 	"gopkg.in/errgo.v1"
@@ -14,8 +13,6 @@ import (
 
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 )
-
-var logger = loggo.GetLogger("httpbakery.form")
 
 /*
 PROTOCOL

--- a/httpbakery/oven.go
+++ b/httpbakery/oven.go
@@ -77,7 +77,6 @@ func (oven *Oven) Error(ctx context.Context, req *http.Request, err error) error
 	if err != nil {
 		return errgo.Notef(err, "cannot mint new macaroon")
 	}
-	logger.Infof("Oven.Error, id %q; cookieName: %q; ops: %#v", m.M().Id(), cookieName, derr.Ops)
 	if err := m.AddCaveat(ctx, checkers.TimeBeforeCaveat(time.Now().Add(expiryDuration)), nil, nil); err != nil {
 		return errgo.Notef(err, "cannot add time-before caveat")
 	}

--- a/httpbakery/visitor.go
+++ b/httpbakery/visitor.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 // TODO(rog) rename this file.
@@ -20,13 +21,15 @@ import (
 // response as a map[string]string.
 //
 // It uses the given Doer to execute the HTTP GET request.
-func legacyGetInteractionMethods(ctx context.Context, client httprequest.Doer, u *url.URL) map[string]*url.URL {
+func legacyGetInteractionMethods(ctx context.Context, logger bakery.Logger, client httprequest.Doer, u *url.URL) map[string]*url.URL {
 	methodURLs, err := legacyGetInteractionMethods1(ctx, client, u)
 	if err != nil {
 		// When a discharger doesn't support retrieving interaction methods,
 		// we expect to get an error, because it's probably returning an HTML
 		// page not JSON.
-		logger.Debugf("ignoring error: cannot get interaction methods: %v; %s", err, errgo.Details(err))
+		if logger != nil {
+			logger.Debugf(ctx, "ignoring error: cannot get interaction methods: %v; %s", err, errgo.Details(err))
+		}
 		methodURLs = make(map[string]*url.URL)
 	}
 	if methodURLs["interactive"] == nil {

--- a/httpbakery/visitor_test.go
+++ b/httpbakery/visitor_test.go
@@ -8,6 +8,7 @@ import (
 
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
@@ -26,7 +27,7 @@ func (*InteractorSuite) TestLegacyGetInteractionMethodsGetFailure(c *gc.C) {
 	}))
 	defer srv.Close()
 
-	methods := httpbakery.LegacyGetInteractionMethods(testContext, http.DefaultClient, mustParseURL(srv.URL))
+	methods := httpbakery.LegacyGetInteractionMethods(testContext, nopLogger{}, http.DefaultClient, mustParseURL(srv.URL))
 	// On error, it falls back to just the single default interactive method.
 	c.Assert(methods, jc.DeepEquals, map[string]*url.URL{
 		"interactive": mustParseURL(srv.URL),
@@ -40,7 +41,7 @@ func (*InteractorSuite) TestLegacyGetInteractionMethodsSuccess(c *gc.C) {
 	}))
 	defer srv.Close()
 
-	methods := httpbakery.LegacyGetInteractionMethods(testContext, http.DefaultClient, mustParseURL(srv.URL))
+	methods := httpbakery.LegacyGetInteractionMethods(testContext, nopLogger{}, http.DefaultClient, mustParseURL(srv.URL))
 	c.Assert(methods, jc.DeepEquals, map[string]*url.URL{
 		"interactive": mustParseURL(srv.URL),
 		"method":      mustParseURL("http://somewhere/something"),
@@ -54,10 +55,15 @@ func (*InteractorSuite) TestLegacyGetInteractionMethodsInvalidURL(c *gc.C) {
 	}))
 	defer srv.Close()
 
-	methods := httpbakery.LegacyGetInteractionMethods(testContext, http.DefaultClient, mustParseURL(srv.URL))
+	methods := httpbakery.LegacyGetInteractionMethods(testContext, nopLogger{}, http.DefaultClient, mustParseURL(srv.URL))
 
 	// On error, it falls back to just the single default interactive method.
 	c.Assert(methods, jc.DeepEquals, map[string]*url.URL{
 		"interactive": mustParseURL(srv.URL),
 	})
 }
+
+type nopLogger struct{}
+
+func (nopLogger) Debugf(context.Context, string, ...interface{}) {}
+func (nopLogger) Infof(context.Context, string, ...interface{})  {}


### PR DESCRIPTION
This means we can use an externally defined logger
if needed. There are a few places where this was awkward
because there was no place to put the Logger, but
those log messages don't seem important enough
to justify a backwardly incompatible API or separate
entry points, so they've been removed.

Rethinking the actual log messages printed is left
for another PR.