### PR TITLE
httpbakery: add global AllowInsecureThirdPartyLocator variable

### DIFF
--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -146,6 +146,14 @@ func (s *suite) TestConcurrentDischargers(c *gc.C) {
 	c.Assert(http.DefaultTransport.(*http.Transport).TLSClientConfig.InsecureSkipVerify, gc.Equals, false)
 }
 
+func (s *suite) TestWithGlobalAllowInsecure(c *gc.C) {
+	httpbakery.AllowInsecureThirdPartyLocator = true
+	defer func() {
+		httpbakery.AllowInsecureThirdPartyLocator = false
+	}()
+	s.TestDischargerSimple(c)
+}
+
 func (s *suite) TestInteractiveDischarger(c *gc.C) {
 	d := bakerytest.NewDischarger(nil)
 	defer d.Close()

--- a/httpbakery/keyring.go
+++ b/httpbakery/keyring.go
@@ -34,6 +34,12 @@ func NewThirdPartyLocator(client httprequest.Doer, cache *bakery.ThirdPartyStore
 	}
 }
 
+// AllowInsecureThirdPartyLocator holds whether ThirdPartyLocator allows
+// insecure HTTP connections for fetching third party information.
+// It is provided for testing purposes and should not be used
+// in production code.
+var AllowInsecureThirdPartyLocator = false
+
 // ThirdPartyLocator represents locator that can interrogate
 // third party discharge services for information. By default it refuses
 // to use insecure URLs.
@@ -44,7 +50,7 @@ type ThirdPartyLocator struct {
 }
 
 // AllowInsecure allows insecure URLs. This can be useful
-// for testing purposes.
+// for testing purposes. See also AllowInsecureThirdPartyLocator.
 func (kr *ThirdPartyLocator) AllowInsecure() {
 	kr.allowInsecure = true
 }
@@ -58,7 +64,7 @@ func (kr *ThirdPartyLocator) ThirdPartyInfo(ctx context.Context, loc string) (ba
 	if err != nil {
 		return bakery.ThirdPartyInfo{}, errgo.Notef(err, "invalid discharge URL %q", loc)
 	}
-	if u.Scheme != "https" && !kr.allowInsecure {
+	if u.Scheme != "https" && !kr.allowInsecure && !AllowInsecureThirdPartyLocator {
 		return bakery.ThirdPartyInfo{}, errgo.Newf("untrusted discharge URL %q", loc)
 	}
 	info, err := kr.cache.ThirdPartyInfo(ctx, loc)

--- a/httpbakery/request.go
+++ b/httpbakery/request.go
@@ -80,10 +80,9 @@ func (rreq *retryableRequest) do(ctx context.Context) (*http.Response, error) {
 func (rreq *retryableRequest) prepare() (*http.Request, error) {
 	req := new(http.Request)
 	*req = *rreq.req
-	// Make sure that the original cookie header is
-	// still in place so that we only end up with the
-	// cookies that are actually added by the
-	// HTTP cookie logic, and not the ones that were
+	// Make sure that the original cookie header is still in place
+	// so that we only end up with the cookies that are actually
+	// added by the HTTP cookie logic, and not the ones that were
 	// added in previous requests too.
 	req.Header.Set("Cookie", rreq.origCookie)
 	if rreq.body == nil {


### PR DESCRIPTION
This means that parallel tests can use bakerytest.NewDischarger without
worrying about global races involving http.DefaultTransport.