### PR TITLE
httpbakery: use OpenWebBrowser method in legacy interactor

### DIFF
--- a/httpbakery/agent/cookie.go
+++ b/httpbakery/agent/cookie.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 
@@ -19,26 +18,6 @@ type agentLogin struct {
 	PublicKey *bakery.PublicKey `json:"public_key"`
 }
 
-// addCookie adds an agent-login cookie with the specified parameters to
-// the given request.
-func addCookie(req *http.Request, username string, key *bakery.PublicKey) {
-	al := agentLogin{
-		Username:  username,
-		PublicKey: key,
-	}
-	data, err := json.Marshal(al)
-	if err != nil {
-		// This should be impossible as the agentLogin structure
-		// has to be marshalable. It is certainly a bug if it
-		// isn't.
-		panic(errgo.Notef(err, "cannot marshal %s cookie", cookieName))
-	}
-	req.AddCookie(&http.Cookie{
-		Name:  cookieName,
-		Value: base64.StdEncoding.EncodeToString(data),
-	})
-}
-
 // ErrNoAgentLoginCookie is the error returned when the expected
 // agent login cookie has not been found.
 var ErrNoAgentLoginCookie = errgo.New("no agent-login cookie found")
@@ -46,6 +25,9 @@ var ErrNoAgentLoginCookie = errgo.New("no agent-login cookie found")
 // LoginCookie returns details of the agent login cookie
 // from the given request. If no agent-login cookie is found,
 // it returns an ErrNoAgentLoginCookie error.
+//
+// This function is only applicable to the legacy agent
+// protocol and will be deprecated in the future.
 func LoginCookie(req *http.Request) (username string, key *bakery.PublicKey, err error) {
 	c, err := req.Cookie(cookieName)
 	if err != nil {

--- a/httpbakery/agent/export_test.go
+++ b/httpbakery/agent/export_test.go
@@ -1,3 +1,5 @@
 package agent
 
-var AddCookie = addCookie
+type AgentLogin agentLogin
+
+const CookieName = cookieName

--- a/httpbakery/browser.go
+++ b/httpbakery/browser.go
@@ -143,14 +143,21 @@ func (wi WebBrowserInteractor) Interact(ctx context.Context, client *Client, loc
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make relative wait URL")
 	}
+	if err := wi.openWebBrowser(visitURL); err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return waitForToken(ctx, client, waitTokenURL)
+}
+
+func (wi WebBrowserInteractor) openWebBrowser(u *url.URL) error {
 	open := wi.OpenWebBrowser
 	if open == nil {
 		open = OpenWebBrowser
 	}
-	if err := open(visitURL); err != nil {
-		return nil, errgo.Mask(err)
+	if err := open(u); err != nil {
+		return errgo.Mask(err)
 	}
-	return waitForToken(ctx, client, waitTokenURL)
+	return nil
 }
 
 // waitForToken returns a token from a the waitToken URL
@@ -182,5 +189,8 @@ func waitForToken(ctx context.Context, client *Client, waitTokenURL *url.URL) (*
 
 // LegacyInteract implements LegacyInteractor by opening a web browser page.
 func (wi WebBrowserInteractor) LegacyInteract(ctx context.Context, client *Client, location string, visitURL *url.URL) error {
-	return OpenWebBrowser(visitURL)
+	if err := wi.openWebBrowser(visitURL); err != nil {
+		return errgo.Mask(err)
+	}
+	return nil
 }


### PR DESCRIPTION
It was an oversight that we didn't use the configured OpenWebBrowser field.

Also move the addCookie function out of the httpbakery/agent production code,
as it's not used any more, and comment that the LoginCookie function
is deprecated.