### PR TITLE
httpbakery: make ResponseWriter available in discharger

### DIFF
--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -65,7 +65,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 		return nil, nil
 	}
 	d1 := bakerytest.NewDischarger(nil)
-	d1.Checker = bakerytest.ConditionParser(d1checker)
+	d1.CheckerP = bakerytest.ConditionParser(d1checker)
 	defer d1.Close()
 	d2checker := func(cond, arg string) ([]checkers.Caveat, error) {
 		return []checkers.Caveat{{
@@ -74,7 +74,7 @@ func (s *suite) TestDischargerTwoLevels(c *gc.C) {
 		}}, nil
 	}
 	d2 := bakerytest.NewDischarger(d1)
-	d2.Checker = bakerytest.ConditionParser(d2checker)
+	d2.CheckerP = bakerytest.ConditionParser(d2checker)
 	defer d2.Close()
 	locator := bakery.NewThirdPartyStore()
 	locator.AddInfo(d1.Location(), bakery.ThirdPartyInfo{

--- a/httpbakery/oven_test.go
+++ b/httpbakery/oven_test.go
@@ -162,8 +162,8 @@ type testIdentityServer struct {
 }
 
 func newTestIdentityServer() *testIdentityServer {
-	checker := func(ctx context.Context, req *http.Request, cav *bakery.ThirdPartyCaveatInfo, token *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
-		if string(cav.Condition) != "is-authenticated-user" {
+	checker := func(ctx context.Context, p httpbakery.ThirdPartyCaveatCheckerParams) ([]checkers.Caveat, error) {
+		if string(p.Caveat.Condition) != "is-authenticated-user" {
 			return nil, errgo.New("unexpected caveat")
 		}
 		return []checkers.Caveat{
@@ -171,7 +171,7 @@ func newTestIdentityServer() *testIdentityServer {
 		}, nil
 	}
 	discharger := bakerytest.NewDischarger(nil)
-	discharger.Checker = httpbakery.ThirdPartyCaveatCheckerFunc(checker)
+	discharger.CheckerP = httpbakery.ThirdPartyCaveatCheckerPFunc(checker)
 	return &testIdentityServer{
 		Discharger: discharger,
 	}


### PR DESCRIPTION
The identity manager wants to be able to set cookies in
the discharge response, but the current Discharger implementation
does not easily allow third party caveat checkers to do that.

This PR adds a new interface type, ThirdPartyCaveatCheckerP,
that is used in preference to the old checker type, and makes
the response writer (and potentially more things in the future) available.

Technically this change breaks backward compatibility in the bakerytest package,
but our estimation is that this will not break any packages in the wild.