### PR TITLE
bakery: add PrivateKey.Public method

### DIFF
--- a/bakery/keys.go
+++ b/bakery/keys.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
@@ -29,6 +30,13 @@ type PublicKey struct {
 // PrivateKey is a 256-bit Ed25519 private key.
 type PrivateKey struct {
 	Key
+}
+
+// Public derives the public key from a private key.
+func (k PrivateKey) Public() PublicKey {
+	var pub PublicKey
+	curve25519.ScalarBaseMult((*[32]byte)(&pub.Key), (*[32]byte)(&k.Key))
+	return pub
 }
 
 // Key is a 256-bit Ed25519 key.

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -135,6 +135,11 @@ public: 7ZcOvDAW9opAIPzJ7FdSbz2i2qL8bFZapDlmNLpMzpU=
 	c.Assert(err, gc.ErrorMatches, `missing private key`)
 }
 
+func (*KeysSuite) TestDerivePublicFromPrivate(c *gc.C) {
+	k := mustGenerateKey()
+	c.Assert(k.Private.Public(), gc.Equals, k.Public)
+}
+
 func newTestKey(n byte) bakery.Key {
 	var k bakery.Key
 	for i := range k {


### PR DESCRIPTION
It's easy to derive a public key from the private key, so provide
a method to do so, potentially allowing smaller private key tokens
if needed.