### PR TITLE
httpbakery: allow untrusted URLs in ThirdPartyLocator cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.12

--- a/httpbakery/keyring_test.go
+++ b/httpbakery/keyring_test.go
@@ -34,6 +34,23 @@ func TestCachePrepopulated(t *testing.T) {
 	c.Assert(info, qt.DeepEquals, expectInfo)
 }
 
+func TestCachePrepopulatedInsecure(t *testing.T) {
+	c := qt.New(t)
+	// We allow an insecure URL in a prepopulated cache.
+	cache := bakery.NewThirdPartyStore()
+	key, err := bakery.GenerateKey()
+	c.Assert(err, qt.Equals, nil)
+	expectInfo := bakery.ThirdPartyInfo{
+		PublicKey: key.Public,
+		Version:   bakery.LatestVersion,
+	}
+	cache.AddInfo("http://0.1.2.3/", expectInfo)
+	kr := httpbakery.NewThirdPartyLocator(nil, cache)
+	info, err := kr.ThirdPartyInfo(testContext, "http://0.1.2.3/")
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(info, qt.DeepEquals, expectInfo)
+}
+
 func TestCacheMiss(t *testing.T) {
 	c := qt.New(t)
 	d := bakerytest.NewDischarger(nil)


### PR DESCRIPTION
This provides a straightforward way for services to conditionally
add known public keys for insecure URLs without needing to
impelement bakery.ThirdPartyLocator themselves.