### PR TITLE
bakery/checkers: add Namespace.Equal

### DIFF
--- a/bakery/checkers/namespace.go
+++ b/bakery/checkers/namespace.go
@@ -18,6 +18,23 @@ type Namespace struct {
 	uriToPrefix map[string]string
 }
 
+// Equal reports whether ns2 encodes the same namespace
+// as the receiver.
+func (ns1 *Namespace) Equal(ns2 *Namespace) bool {
+	if ns1 == ns2 || ns1 == nil || ns2 == nil {
+		return ns1 == ns2
+	}
+	if len(ns1.uriToPrefix) != len(ns2.uriToPrefix) {
+		return false
+	}
+	for k, v := range ns1.uriToPrefix {
+		if ns2.uriToPrefix[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 // NewNamespace returns a new namespace with the
 // given initial contents. It will panic if any of the
 // URI keys or their associated prefix are invalid

--- a/bakery/checkers/namespace_test.go
+++ b/bakery/checkers/namespace_test.go
@@ -66,6 +66,45 @@ func (*NamespaceSuite) TestRegister(c *gc.C) {
 	c.Assert(ok, gc.Equals, true)
 }
 
+var namespaceEqualTests = []struct{
+	about string
+	ns1, ns2 *checkers.Namespace
+	expect bool
+}{{
+	about: "both nil",
+	expect: true,
+}, {
+	about: "ns1 nil",
+	ns2: checkers.NewNamespace(nil),
+	expect: false,
+}, {
+	about: "ns2 nil",
+	ns1: checkers.NewNamespace(nil),
+	expect: false,
+}, {
+	about: "different lengths",
+	ns1: checkers.NewNamespace(map[string]string{"testns": "t", "otherns": "t"}),
+	ns2: checkers.NewNamespace(map[string]string{"testns": "t"}),
+	expect: false,
+}, {
+	about: "all same",
+	ns1: checkers.NewNamespace(map[string]string{"testns": "t", "otherns": "t"}),
+	ns2: checkers.NewNamespace(map[string]string{"testns": "t", "otherns": "t"}),
+	expect: true,
+}, {
+	about: "different contents",
+	ns1: checkers.NewNamespace(map[string]string{"testns": "t", "otherns": "t"}),
+	ns2: checkers.NewNamespace(map[string]string{"testns": "t1", "otherns": "t"}),
+	expect: false,
+}}
+
+func (*NamespaceSuite) TestEqual(c *gc.C) {
+	for i, test := range namespaceEqualTests {
+		c.Logf("test %d: %s", i, test.about)
+		c.Assert(test.ns1.Equal(test.ns2), gc.Equals, test.expect)
+	}
+}
+
 func (*NamespaceSuite) TestRegisterBadURI(c *gc.C) {
 	ns := checkers.NewNamespace(nil)
 	c.Assert(func() {


### PR DESCRIPTION
This will allow us to use Namespace with cmp.Equal.