### PR TITLE
bakery: avoid direct loggo dependency

### DIFF
--- a/bakery/bakery.go
+++ b/bakery/bakery.go
@@ -21,8 +21,7 @@ type Bakery struct {
 // or third party caveats to be added.
 type BakeryParams struct {
 	// Logger is used to send log messages. If it is nil,
-	// DefaultLogger("bakery") will be used.
-	// github.com/juju/loggo will be used for logging.
+	// nothing will be logged.
 	Logger Logger
 
 	// Checker holds the checker used to check first party caveats.

--- a/bakery/logger.go
+++ b/bakery/logger.go
@@ -2,8 +2,6 @@ package bakery
 
 import (
 	"context"
-
-	"github.com/juju/loggo"
 )
 
 // Logger is used by the bakery to log informational messages
@@ -13,23 +11,18 @@ type Logger interface {
 	Debugf(ctx context.Context, f string, args ...interface{})
 }
 
-// DefaultLogger returns a Logger instance that uses
-// github.com/juju/loggo to log messages using the
-// given logger name.
+// DefaultLogger returns a Logger instance that does nothing.
+//
+// Deprecated: DefaultLogger exists for historical compatibility
+// only. Previously it logged using github.com/juju/loggo.
 func DefaultLogger(name string) Logger {
-	return loggoLogger{loggo.GetLogger(name)}
+	return nopLogger{}
 }
 
-type loggoLogger struct {
-	logger loggo.Logger
-}
+type nopLogger struct{}
 
 // Debugf implements Logger.Debugf.
-func (l loggoLogger) Debugf(_ context.Context, f string, args ...interface{}) {
-	l.logger.Debugf(f, args...)
-}
+func (nopLogger) Debugf(context.Context, string, ...interface{}) {}
 
 // Debugf implements Logger.Infof.
-func (l loggoLogger) Infof(_ context.Context, f string, args ...interface{}) {
-	l.logger.Infof(f, args...)
-}
+func (nopLogger) Infof(context.Context, string, ...interface{}) {}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/frankban/quicktest v1.2.2
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42
-	github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9
 	github.com/juju/mgotest v1.0.1
 	github.com/juju/postgrestest v1.0.1
 	github.com/juju/qthttptest v0.0.1
@@ -13,7 +12,7 @@ require (
 	github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
 	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
-	gopkg.in/errgo.v1 v1.0.0
+	gopkg.in/errgo.v1 v1.0.1
 	gopkg.in/httprequest.v1 v1.2.0
 	gopkg.in/juju/environschema.v1 v1.0.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9 h1:Y+lzErDTURqeXqlqYi4YBYbDd7ycU74gW1ADt57/bgY=
-github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/mgotest v1.0.1 h1:XvuZ2whmkHZ5G+Y/wQaSe28p2FyTwcBaqTzStn+QaLc=
 github.com/juju/mgotest v1.0.1/go.mod h1:vTaDufYul+Ps8D7bgseHjq87X8eu0ivlKLp9mVc/Bfc=
 github.com/juju/postgrestest v1.0.1 h1:kTfj8tBtE6Pgevm+eJN9PPj3jysaJBucoqD4xZ7ftsA=
@@ -49,6 +47,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v1 v1.0.0 h1:n+7XfCyygBFb8sEjg6692xjC6Us50TFRO54+xYUEwjE=
 gopkg.in/errgo.v1 v1.0.0/go.mod h1:CxwszS/Xz1C49Ucd2i6Zil5UToP1EmyrFhKaMVbg1mk=
+gopkg.in/errgo.v1 v1.0.1 h1:oQFRXzZ7CkBGdm1XZm/EbQYaYNNEElNBOd09M6cqNso=
+gopkg.in/errgo.v1 v1.0.1/go.mod h1:3NjfXwocQRYAPTq4/fzX+CwUhPRcR/azYRhj8G+LqMo=
 gopkg.in/httprequest.v1 v1.2.0 h1:YTGV1oXzaoKI6oPzQ0knoIPcrrVzeRG3amkoxoP7Xng=
 gopkg.in/httprequest.v1 v1.2.0/go.mod h1:T61ZUaJLpMnzvoJDO03ZD8yRXD4nZzBeDoW5e9sffjg=
 gopkg.in/juju/environschema.v1 v1.0.0 h1:51vT1bzbP9fntQ0I9ECSlku2p19Szj/N2beZFeIH2kM=


### PR DESCRIPTION
If anyone actually needs these log messages
sending to loggo, they can do so by implementing
bakery.Logger themselves.