### PR TITLE
Check PKs in bakery example

### DIFF
--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -15,7 +15,7 @@ import (
 func authService(endpoint string, key *bakery.KeyPair) (http.Handler, error) {
 	d := httpbakery.NewDischarger(httpbakery.DischargerParams{
 		Checker: httpbakery.ThirdPartyCaveatCheckerFunc(thirdPartyChecker),
-		Key:     bakery.MustGenerateKey(),
+		Key:     key,
 	})
 
 	mux := http.NewServeMux()

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -31,8 +31,17 @@ func targetService(endpoint, authEndpoint string, authPK *bakery.PublicKey) (htt
 	if err != nil {
 		return nil, err
 	}
-	pkLocator := httpbakery.NewThirdPartyLocator(nil, nil)
-	pkLocator.AllowInsecure()
+	cache := bakery.NewThirdPartyStore()
+	// NB: in the real world, authEndpoint would be https (here it's http) and
+	// so the third party locator could retrieve the ThirdPartyInfo securely
+	// automatically. For the sake of clarity in this example, assume the info
+	// is encoded statically, to avoid the http request to an untrusted
+	// endpoint. (We could also use pkLocator.AllowInsecure() instead).
+	cache.AddInfo(authEndpoint, bakery.ThirdPartyInfo{
+		PublicKey: *authPK,
+		Version: bakery.LatestVersion,
+	})
+	pkLocator := httpbakery.NewThirdPartyLocator(nil, cache)
 	b := identchecker.NewBakery(identchecker.BakeryParams{
 		Key:      key,
 		Location: endpoint,


### PR DESCRIPTION
In the example, the target service was using an insecure third party
locator, so it wasn't really demonstrating much.