### PR TITLE
Update import paths to github.com/go-macaroon-bakery/macaroon-bakery/v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: "gopkg.in/macaroon-bakery.v2"
+go_import_path: "github.com/go-macaroon-bakery/macaroon-bakery/v3"
 go: 
   - "1.12.x"
 script: GO111MODULE=on go test ./...

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ It holds higher level operations for building systems with macaroons.
 
 For documentation, see:
 
-- http://godoc.org/gopkg.in/macaroon-bakery.v2/bakery
-- http://godoc.org/gopkg.in/macaroon-bakery.v2/httpbakery
-- http://godoc.org/gopkg.in/macaroon-bakery.v2/bakery/checkers
+- http://godoc.org/github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery
+- http://godoc.org/github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery
+- http://godoc.org/github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers

--- a/bakery/authstore_test.go
+++ b/bakery/authstore_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 type macaroonStore struct {

--- a/bakery/bakery.go
+++ b/bakery/bakery.go
@@ -1,7 +1,7 @@
 package bakery
 
 import (
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // Bakery is a convenience type that contains both an Oven

--- a/bakery/checker.go
+++ b/bakery/checker.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	macaroon "gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // Op holds an entity and action to be authorized on that entity.

--- a/bakery/checker_test.go
+++ b/bakery/checker_test.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 func TestCapability(t *testing.T) {

--- a/bakery/checkers/checkers_test.go
+++ b/bakery/checkers/checkers_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // A frozen time for the tests.

--- a/bakery/checkers/namespace.go
+++ b/bakery/checkers/namespace.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 )
 
 // Namespace holds maps from schema URIs to the

--- a/bakery/checkers/namespace_test.go
+++ b/bakery/checkers/namespace_test.go
@@ -5,7 +5,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 var resolveTests = []struct {

--- a/bakery/checkers/time_test.go
+++ b/bakery/checkers/time_test.go
@@ -7,7 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 var t1 = time.Now()

--- a/bakery/codec.go
+++ b/bakery/codec.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/nacl/box"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 type caveatRecord struct {

--- a/bakery/codec_test.go
+++ b/bakery/codec_test.go
@@ -7,7 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"golang.org/x/crypto/nacl/box"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 var (

--- a/bakery/common_test.go
+++ b/bakery/common_test.go
@@ -9,8 +9,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // testContext holds the testing background context - its associated time when checking

--- a/bakery/dbrootkeystore/rootkey.go
+++ b/bakery/dbrootkeystore/rootkey.go
@@ -12,7 +12,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 // maxPolicyCache holds the maximum number of store policies that can

--- a/bakery/dbrootkeystore/rootkey_test.go
+++ b/bakery/dbrootkeystore/rootkey_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
 var epoch = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/bakery/discharge.go
+++ b/bakery/discharge.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // LocalThirdPartyCaveat returns a third-party caveat that, when added

--- a/bakery/discharge_test.go
+++ b/bakery/discharge_test.go
@@ -10,8 +10,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // TestSingleServiceFirstParty creates a single service

--- a/bakery/dischargeall.go
+++ b/bakery/dischargeall.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // DischargeAll gathers discharge macaroons for all the third party

--- a/bakery/dischargeall_test.go
+++ b/bakery/dischargeall_test.go
@@ -9,8 +9,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 func alwaysOK(string) error {

--- a/bakery/error.go
+++ b/bakery/error.go
@@ -3,9 +3,9 @@ package bakery
 import (
 	"fmt"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 var (

--- a/bakery/example/authservice.go
+++ b/bakery/example/authservice.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 // authService implements an authorization service,

--- a/bakery/example/client.go
+++ b/bakery/example/client.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 // client represents a client of the target service.

--- a/bakery/example/example_test.go
+++ b/bakery/example/example_test.go
@@ -6,7 +6,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 func TestExample(t *testing.T) {

--- a/bakery/example/main.go
+++ b/bakery/example/main.go
@@ -23,8 +23,8 @@ import (
 	"net"
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 var defaultHTTPClient = httpbakery.NewHTTPClient()

--- a/bakery/example/targetservice.go
+++ b/bakery/example/targetservice.go
@@ -8,10 +8,10 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 type targetServiceHandler struct {

--- a/bakery/identchecker/authorizer.go
+++ b/bakery/identchecker/authorizer.go
@@ -5,8 +5,8 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // Authorizer is used to check whether a given user is allowed

--- a/bakery/identchecker/authorizer_test.go
+++ b/bakery/identchecker/authorizer_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
 )
 
 func TestAuthorizerFunc(t *testing.T) {

--- a/bakery/identchecker/bakery.go
+++ b/bakery/identchecker/bakery.go
@@ -1,8 +1,8 @@
 package identchecker
 
 import (
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 type Bakery struct {

--- a/bakery/identchecker/checker.go
+++ b/bakery/identchecker/checker.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"sync"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // CheckerParams holds parameters for NewChecker.

--- a/bakery/identchecker/checker_test.go
+++ b/bakery/identchecker/checker_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
 )
 
 type dischargeRecord struct {

--- a/bakery/identchecker/common_test.go
+++ b/bakery/identchecker/common_test.go
@@ -7,8 +7,8 @@ import (
 
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // testContext holds the testing background context - its associated time when checking

--- a/bakery/identchecker/identity.go
+++ b/bakery/identchecker/identity.go
@@ -5,7 +5,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // IdentityClient represents an abstract identity manager. User

--- a/bakery/keys_test.go
+++ b/bakery/keys_test.go
@@ -8,7 +8,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 var testKey = newTestKey(0)

--- a/bakery/macaroon.go
+++ b/bakery/macaroon.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // legacyNamespace holds the standard namespace as used by

--- a/bakery/macaroon_test.go
+++ b/bakery/macaroon_test.go
@@ -7,8 +7,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 func TestNewMacaroon(t *testing.T) {

--- a/bakery/mgorootkeystore/rootkey.go
+++ b/bakery/mgorootkeystore/rootkey.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/mgo/v2/bson"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
 // Functions defined as variables so they can be overidden

--- a/bakery/mgorootkeystore/rootkey_test.go
+++ b/bakery/mgorootkeystore/rootkey_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/mgo/v2"
 	"github.com/juju/mgotest"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
-	"gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/mgorootkeystore"
 )
 
 var epoch = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/bakery/oven.go
+++ b/bakery/oven.go
@@ -7,11 +7,11 @@ import (
 	"sort"
 
 	"github.com/rogpeppe/fastuuid"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/internal/macaroonpb"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/internal/macaroonpb"
 )
 
 // MacaroonVerifier verifies macaroons and returns the operations and

--- a/bakery/oven_test.go
+++ b/bakery/oven_test.go
@@ -6,7 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 var canonicalOpsTests = []struct {

--- a/bakery/postgresrootkeystore/export_test.go
+++ b/bakery/postgresrootkeystore/export_test.go
@@ -1,6 +1,6 @@
 package postgresrootkeystore
 
-import "gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+import "github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 
 var (
 	Clock      = &clock

--- a/bakery/postgresrootkeystore/rootkey.go
+++ b/bakery/postgresrootkeystore/rootkey.go
@@ -9,8 +9,8 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
 // Variables defined so they can be overidden for testing.

--- a/bakery/postgresrootkeystore/rootkey_test.go
+++ b/bakery/postgresrootkeystore/rootkey_test.go
@@ -9,11 +9,11 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
 	"github.com/juju/postgrestest"
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
-	"gopkg.in/macaroon-bakery.v2/bakery/postgresrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/postgresrootkeystore"
 )
 
 const testTable = "testrootkeys"

--- a/bakery/postgresrootkeystore/sql.go
+++ b/bakery/postgresrootkeystore/sql.go
@@ -7,10 +7,10 @@ import (
 	"text/template"
 	"time"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/dbrootkeystore"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
 type stmtId int

--- a/bakery/slice.go
+++ b/bakery/slice.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 	macaroon "gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // Slice holds a slice of unbound macaroons.

--- a/bakery/slice_test.go
+++ b/bakery/slice_test.go
@@ -10,8 +10,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 func TestAddMoreCaveats(t *testing.T) {

--- a/bakery/store_test.go
+++ b/bakery/store_test.go
@@ -5,7 +5,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 func TestMemStore(t *testing.T) {

--- a/bakerytest/bakerytest.go
+++ b/bakerytest/bakerytest.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 // Discharger represents a third party caveat discharger server.

--- a/bakerytest/bakerytest_test.go
+++ b/bakerytest/bakerytest_test.go
@@ -14,10 +14,10 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 var dischargeOp = bakery.Op{"thirdparty", "x"}

--- a/bakerytest/rendezvous.go
+++ b/bakerytest/rendezvous.go
@@ -6,11 +6,11 @@ import (
 	"sync"
 	"time"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 // Rendezvous implements a place where discharge information

--- a/cmd/bakery-keygen/main.go
+++ b/cmd/bakery-keygen/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/macaroon-bakery.v2
+module github.com/go-macaroon-bakery/macaroon-bakery/v3
 
 require (
 	github.com/frankban/quicktest v1.7.3

--- a/httpbakery/agent/agent.go
+++ b/httpbakery/agent/agent.go
@@ -18,8 +18,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 // AuthInfo holds the agent information required

--- a/httpbakery/agent/agent_test.go
+++ b/httpbakery/agent/agent_test.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/httprequest.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/agent"
 )
 
 var agentLoginOp = bakery.Op{"agent", "login"}

--- a/httpbakery/agent/cookie.go
+++ b/httpbakery/agent/cookie.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 const cookieName = "agent-login"

--- a/httpbakery/agent/cookie_test.go
+++ b/httpbakery/agent/cookie_test.go
@@ -9,8 +9,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/agent"
 )
 
 var loginCookieTests = []struct {

--- a/httpbakery/agent/example_test.go
+++ b/httpbakery/agent/example_test.go
@@ -1,9 +1,9 @@
 package agent_test
 
 import (
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/agent"
 )
 
 func ExampleSetUpAuth() {

--- a/httpbakery/agent/legacy_test.go
+++ b/httpbakery/agent/legacy_test.go
@@ -10,12 +10,12 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/agent"
 )
 
 type visitFunc func(w http.ResponseWriter, req *http.Request, dischargeId string) error

--- a/httpbakery/browser.go
+++ b/httpbakery/browser.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 const WebBrowserInteractionKind = "browser-window"

--- a/httpbakery/checkers.go
+++ b/httpbakery/checkers.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 type httpRequestKey struct{}

--- a/httpbakery/checkers_test.go
+++ b/httpbakery/checkers_test.go
@@ -8,8 +8,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 type checkTest struct {

--- a/httpbakery/client.go
+++ b/httpbakery/client.go
@@ -16,8 +16,8 @@ import (
 	"gopkg.in/httprequest.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 var unmarshalError = httprequest.ErrorUnmarshaler(&Error{})

--- a/httpbakery/client_test.go
+++ b/httpbakery/client_test.go
@@ -22,10 +22,10 @@ import (
 	"gopkg.in/httprequest.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 var (

--- a/httpbakery/discharge.go
+++ b/httpbakery/discharge.go
@@ -12,8 +12,8 @@ import (
 	"gopkg.in/httprequest.v1"
 	"gopkg.in/macaroon.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // ThirdPartyCaveatChecker is used to check third party caveats.
@@ -206,7 +206,7 @@ func (d *Discharger) Handlers() []httprequest.Handler {
 	return srv.Handlers(f)
 }
 
-//go:generate httprequest-generate-client gopkg.in/macaroon-bakery.v2-unstable/httpbakery dischargeHandler dischargeClient
+//go:generate httprequest-generate-client github.com/go-macaroon-bakery/macaroon-bakery/v3-unstable/httpbakery dischargeHandler dischargeClient
 
 // dischargeHandler is the type used to define the httprequest handler
 // methods for a discharger.

--- a/httpbakery/error.go
+++ b/httpbakery/error.go
@@ -10,8 +10,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/internal/httputil"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/internal/httputil"
 )
 
 // ErrorCode holds an error code that classifies

--- a/httpbakery/error_test.go
+++ b/httpbakery/error_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/qthttptest"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 func TestWriteDischargeRequiredError(t *testing.T) {

--- a/httpbakery/form/form.go
+++ b/httpbakery/form/form.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 /*

--- a/httpbakery/form/form_test.go
+++ b/httpbakery/form/form_test.go
@@ -12,12 +12,12 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	esform "gopkg.in/juju/environschema.v1/form"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/form"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/form"
 )
 
 var reqServer = httprequest.Server{

--- a/httpbakery/keyring.go
+++ b/httpbakery/keyring.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 var _ bakery.ThirdPartyLocator = (*ThirdPartyLocator)(nil)

--- a/httpbakery/keyring_test.go
+++ b/httpbakery/keyring_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 func TestCachePrepopulated(t *testing.T) {

--- a/httpbakery/oven.go
+++ b/httpbakery/oven.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"time"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 )
 
 // Oven is like bakery.Oven except it provides a method for

--- a/httpbakery/oven_test.go
+++ b/httpbakery/oven_test.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	"gopkg.in/macaroon-bakery.v2/bakerytest"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakerytest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 func TestOvenWithAuthnMacaroon(t *testing.T) {

--- a/httpbakery/request.go
+++ b/httpbakery/request.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/errgo.v1"
 )
 
 // newRetrableRequest wraps an HTTP request so that it can

--- a/httpbakery/visitor.go
+++ b/httpbakery/visitor.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 )
 
 // TODO(rog) rename this file.

--- a/httpbakery/visitor_test.go
+++ b/httpbakery/visitor_test.go
@@ -10,7 +10,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 )
 
 func TestLegacyGetInteractionMethodsGetFailure(t *testing.T) {

--- a/internal/httputil/relativeurl_test.go
+++ b/internal/httputil/relativeurl_test.go
@@ -11,7 +11,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"gopkg.in/macaroon-bakery.v2/internal/httputil"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/internal/httputil"
 )
 
 var relativeURLTests = []struct {


### PR DESCRIPTION
With this v3 version importing from github.com/juju/mgo/v2, also update this repo to import from 
github.com/go-macaroon-bakery/macaroon-bakery/v3
instead of 
gopkg.in/macaroon-bakery.v2